### PR TITLE
Add Grid Intensity CLI Docs

### DIFF
--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -98,11 +98,11 @@
                     <p class="divider text-sm font-bold font-mono">{{ sectionTitle }}</p>
                   </li>
                 {% endif %}
-                <li {% if entry.url == page.url %} class="bg-secondary text-white" {% endif %}>
+                <li {% if entry.url == page.url %} class="bg-secondary text-white pl-4" {%else%} class="pl-4" {% endif %}>
                   <a href="{{ entry.url | url }}">{{ entry.title }}</a>
                   {%- if entry.children.length -%}
                     {%- for child in entry.children %}
-                      <li {% if child.url == page.url %} class="bg-secondary text-white" {% endif %}>
+                      <li {% if child.url == page.url %} class="bg-secondary text-white pl-4" {%else%} class="pl-4" {% endif %}>
                         <a href="{{ child.url | url }}">{{ child.title }}</a>
                       {% endfor -%}
                     </li>

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -83,7 +83,7 @@
               {% else %}
                 {% set openCollapse = '' %}
               {% endif %}
-              <ul tabindex="0" class="collapse collapse-arrow rounded-box border border-base-300">
+              <ul tabindex="0" class="collapse collapse-arrow rounded-box">
                 <li>
                     <input type="checkbox" aria-label="Expand {{ main.data.libraryName }}"class="peer invisible absolute" {{ openCollapse }}/>
                   <div class="collapse-title">

--- a/src/_includes/snippets/watttime-registration.md
+++ b/src/_includes/snippets/watttime-registration.md
@@ -1,6 +1,6 @@
 ### Registration
 
-Before using the WattTime integration, you must first create a user account with WattTime. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
+Before using the WattTime integration, you must first create a user account. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
 
 Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
 

--- a/src/_includes/snippets/watttime-registration.md
+++ b/src/_includes/snippets/watttime-registration.md
@@ -1,0 +1,10 @@
+### Registration
+
+Before using the WattTime integration, you must first create a user account with WattTime. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
+
+Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
+
+```bash
+export WATT_TIME_USER=your-username
+export WATT_TIME_PASSWORD=your-password
+```

--- a/src/docs/co2js/explainer/methodologies-for-calculating-website-carbon.md
+++ b/src/docs/co2js/explainer/methodologies-for-calculating-website-carbon.md
@@ -1,6 +1,6 @@
 ---
 title: Methodologies for calculating website carbon
-description: CO2.js offers two models for understanding the environmental impact of compute - the 1byte model, and the Sustainable Web Design model."
+description: CO2.js offers two models for understanding the environmental impact of compute - the 1byte model, and the Sustainable Web Design model.
 eleventyNavigation:
   key: website-carbon-methodologies
   # parent: overview

--- a/src/docs/co2js/installation.md
+++ b/src/docs/co2js/installation.md
@@ -7,11 +7,11 @@ eleventyNavigation:
   order: 2
 ---
 
-## Installation
+# Installation
 
 This guide will show you how to quickly get started with CO2.js in a variety of ways.
 
-### Using NPM
+## Using NPM
 
 You can install CO2.js as a dependency for your projects using NPM.
 
@@ -19,7 +19,7 @@ You can install CO2.js as a dependency for your projects using NPM.
 npm install @tgwf/co2
 ```
 
-### Using Skypack
+## Using Skypack
 
 You can import the CO2.js library into projects using Skypack.
 
@@ -28,7 +28,7 @@ import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
 ```
 
 
-### Build it yourself
+## Build it yourself
 
 {% betaCodeWarning 'https://github.com/thegreenwebfoundation/co2.js/pull/92' %}
 

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -1,0 +1,167 @@
+---
+title: Providers
+description: CO2.js offers two models for understanding the environmental impact of compute - the 1byte model, and the Sustainable Web Design model."
+eleventyNavigation:
+  key: providers
+  # parent: overview
+  title: Providers
+  sectionTitle: Explanations
+  order: 30
+---
+# {{ title }}
+
+The Grid Intensity CLI allows data to be sourced from several providers. Currently there are integrations available for the following providers:
+
+- [WattTime](https://www.watttime.org/)
+- [Ember](https://ember-climate.org/)
+- [Electricity Maps](https://electricitymaps.com/)
+- [UK Carbon Intensity API](https://carbonintensity.org.uk/)
+
+If you would like us to integrate more providers please [open an issue](https://github.com/thegreenwebfoundation/grid-intensity-go/issues).
+
+## Changing providers
+
+When running the Grid Intensity CLI, you can change providers by passing the `--provider` flag, along with the name of the provider you want to use. Alternately, you can set `GRID_INTENSITY_PROVIDER` as an environment variable.
+
+<aside class="alert bg-base-200 text-base-content"><p>Please note that some providers require user account and/or API tokens to be set as well. Details for these are listed below with each provider.</p></aside>
+
+When no provider is set, the CLI will use Ember as the default.
+
+## Ember <span class="badge align-middle badge-secondary badge-lg">Default</span>
+
+Ember is an energy think tank that uses data-driven insights to shift the world from coal to clean electricity.
+
+`--provider=ember-climate.org`
+
+Ember is the default provider for the Grid Intensity CLI. The Ember integration returns regional data by country, for the last calendar year.
+
+### Required parameters
+
+When using Ember, you will need to pass either an [Alpha-2 or Alpha-3 ISO country code](https://www.iso.org/obp/ui/#search) for the region you want data for. You can do this using the `--region` flag.
+
+For example, the code below returns data for Taiwan.
+
+```bash
+grid-intensity --provider=ember-climate.org --region=TW
+
+# Returns
+
+{
+	"country_code_iso_2": "TW",
+	"country_code_iso_3": "TWN",
+	"country_or_region": "Taiwan (Province of China)",
+	"year": 2021,
+	"latest_year": 2021,
+	"emissions_intensity_gco2_per_kwh": 565.629
+}
+```
+
+***
+
+## WattTime <div class="badge badge-warning gap-2 align-middle">Registration required</div>
+
+WattTime is a nonprofit that offers technology solutions that make it easy for anyone to achieve emissions reductions without compromising cost, comfort, and function.
+
+`--provider=watttime.org`
+
+
+### Registration
+
+Before using the WattTime integration, you must first create a user account with WattTime. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
+
+Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
+
+```bash
+export WATT_TIME_USER=your-username
+export WATT_TIME_PASSWORD=your-password
+```
+
+### Required parameters
+
+When using WattTime, you will need to pass a region that is supported by the WattTime API. WattTime's API documentation details how you can [get a list of regions](https://www.watttime.org/api-documentation/#list-of-grid-regions), or [use latitude & longitude](https://www.watttime.org/api-documentation/#determine-grid-region) to find a specific region.
+
+For example, running the command below returns data for California Independent System Operator (North). 
+
+```bash
+grid-intensity --provider=watttime.org --region=CAISO_NORTH                                                                                                            ─╯
+
+## Returns
+
+{
+	"ba": "CAISO_NORTH",
+	"freq": "300",
+	"moer": "887",
+	"percent": "38",
+	"point_time": "2022-07-28T01:40:00Z"
+}
+```
+
+### Limitations
+
+Each region will return a `percent` value. This value represents the relative realtime marginal emissions intensity for the _past month_.
+
+If you require Marginal Operating Emissions Rate (MOER) data, this is available for free when querying the `CAISO_NORTH` region but will require a _WattTime Pro subscription_ for other regions.
+
+
+***
+
+## Electrity Map <div class="badge badge-warning gap-2 align-middle">API token required</div>
+
+The Electricity Maps API provides worldwide access to 24/7 grid carbon intensity historically, in real time, and as a forecast for the next 24 hours.
+
+`--provider=electricitymap.org`
+
+### Registration
+
+Before using the Electricy Map integration, you must first [obtain an API key](https://static.electricitymap.org/api/docs/index.html#authentication). This will allow you to access and use their API.
+
+Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
+
+```bash
+export ELECTRICITY_MAP_API_TOKEN=your-token
+```
+
+### Required parameters
+
+When using Electricity Map, you will need to pass a region that is supported by the Electricity Map API. You can get a [list of all supported regions](https://static.electricitymap.org/api/docs/index.html#zones) using the Electricity Map API.
+
+For example, running the command below will return data for Portugal.
+
+```bash
+grid-intensity --provider=electricitymap.org --region=PT
+
+# Returns
+
+
+```
+
+***
+
+## UK Carbon Intensity API
+
+National Grid ESO have developed a Regional Carbon Intensity forecast for the Great Britain electricity grid.
+
+`--provider=carbonintensity.org.uk`
+
+### Required parameters
+
+The UK Carbon Intensity API integration supports only one region, `UK`. This can be passed to the CLI as an optional parameter.
+
+For example, the code below returns data for the UK.
+
+```bash
+grid-intensity --provider=carbonintensity.org.uk
+
+# Returns
+
+{
+	"from": "2022-07-28T02:00Z",
+	"to": "2022-07-28T02:30Z",
+	"intensity": {
+		"forecast": 272,
+		"actual": 0,
+		"index": "high"
+	}
+}
+
+```

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -67,16 +67,7 @@ WattTime is a nonprofit that offers technology solutions that make it easy for a
 
 `--provider=watttime.org`
 
-### Registration
-
-Before using the WattTime integration, you must first create a user account with WattTime. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
-
-Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
-
-```bash
-export WATT_TIME_USER=your-username
-export WATT_TIME_PASSWORD=your-password
-```
+{% include 'snippets/watttime-registration.md' %}
 
 ### Required parameters
 

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -122,10 +122,6 @@ For example, running the command below will return data for Portugal.
 
 ```bash
 grid-intensity --provider=electricitymap.org --region=PT
-
-# Returns
-
-
 ```
 
 ***

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -1,6 +1,6 @@
 ---
 title: Providers
-description: CO2.js offers two models for understanding the environmental impact of compute - the 1byte model, and the Sustainable Web Design model."
+description: The Grid Intensity CLI allows data to be sourced from several providers.
 eleventyNavigation:
   key: providers
   # parent: overview
@@ -10,7 +10,7 @@ eleventyNavigation:
 ---
 # {{ title }}
 
-The Grid Intensity CLI allows data to be sourced from several providers. Currently there are integrations available for the following providers:
+The Grid Intensity CLI allows data to be sourced from several providers. Currently the following integrations are available:
 
 - [WattTime](https://www.watttime.org/)
 - [Ember](https://ember-climate.org/)
@@ -23,9 +23,12 @@ If you would like us to integrate more providers please [open an issue](https://
 
 When running the Grid Intensity CLI, you can change providers by passing the `--provider` flag, along with the name of the provider you want to use. Alternately, you can set `GRID_INTENSITY_PROVIDER` as an environment variable.
 
-<aside class="alert bg-base-200 text-base-content"><p>Please note that some providers require user account and/or API tokens to be set as well. Details for these are listed below with each provider.</p></aside>
-
 When no provider is set, the CLI will use Ember as the default.
+
+<aside class="alert  alert-warning"><div>
+<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+	<p>Please note that some providers require user account and/or API tokens to be set as well.</p>
+</div></aside>
 
 ## Ember <span class="badge align-middle badge-secondary badge-lg">Default</span>
 
@@ -64,7 +67,6 @@ WattTime is a nonprofit that offers technology solutions that make it easy for a
 
 `--provider=watttime.org`
 
-
 ### Registration
 
 Before using the WattTime integration, you must first create a user account with WattTime. This will allow you to access and use their API. Details on registering an account are available on the [WattTime website](https://www.watttime.org/api-documentation/#register-new-user).
@@ -83,9 +85,9 @@ When using WattTime, you will need to pass a region that is supported by the Wat
 For example, running the command below returns data for California Independent System Operator (North). 
 
 ```bash
-grid-intensity --provider=watttime.org --region=CAISO_NORTH                                                                                                            ─╯
+grid-intensity --provider=watttime.org --region=CAISO_NORTH
 
-## Returns
+# Returns
 
 {
 	"ba": "CAISO_NORTH",
@@ -98,9 +100,9 @@ grid-intensity --provider=watttime.org --region=CAISO_NORTH                     
 
 ### Limitations
 
-Each region will return a `percent` value. This value represents the relative realtime marginal emissions intensity for the _past month_.
+Each region will return a `percent` field. This value represents the relative realtime marginal emissions intensity for the _past month_.
 
-If you require Marginal Operating Emissions Rate (MOER) data, this is available for free when querying the `CAISO_NORTH` region but will require a _WattTime Pro subscription_ for other regions.
+If you require Marginal Operating Emissions Rate (MOER) data, this is available for free when querying the `CAISO_NORTH` region but will require a [_WattTime Pro subscription_](https://www.watttime.org/get-the-data/data-plans/) for other regions.
 
 
 ***
@@ -115,7 +117,7 @@ The Electricity Maps API provides worldwide access to 24/7 grid carbon intensity
 
 Before using the Electricy Map integration, you must first [obtain an API key](https://static.electricitymap.org/api/docs/index.html#authentication). This will allow you to access and use their API.
 
-Once you have created a WattTime account, you must set the `WATT_TIME_USER` and `WATT_TIME_PASSWORD` environment variables. This allows the Grid Intensity CLI to access the WattTime API.
+Once you have an Electricity Map API key, you must set the `ELECTRICITY_MAP_API_TOKEN` environment variable. This allows the Grid Intensity CLI to access the Electricity Map API.
 
 ```bash
 export ELECTRICITY_MAP_API_TOKEN=your-token
@@ -123,7 +125,7 @@ export ELECTRICITY_MAP_API_TOKEN=your-token
 
 ### Required parameters
 
-When using Electricity Map, you will need to pass a region that is supported by the Electricity Map API. You can get a [list of all supported regions](https://static.electricitymap.org/api/docs/index.html#zones) using the Electricity Map API.
+When using Electricity Map, you will need to pass a supported region. You can get a [list of all supported regions](https://static.electricitymap.org/api/docs/index.html#zones) using the Electricity Map API.
 
 For example, running the command below will return data for Portugal.
 
@@ -145,7 +147,7 @@ National Grid ESO have developed a Regional Carbon Intensity forecast for the Gr
 
 ### Required parameters
 
-The UK Carbon Intensity API integration supports only one region, `UK`. This can be passed to the CLI as an optional parameter.
+The UK Carbon Intensity API integration supports only one region, `--region=UK`. This can be passed to the CLI as an optional parameter.
 
 For example, the code below returns data for the UK.
 

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -40,7 +40,7 @@ Ember is the default provider for the Grid Intensity CLI. The Ember integration 
 
 ### Required parameters
 
-When using Ember, you will need to pass either an [Alpha-2 or Alpha-3 ISO country code](https://www.iso.org/obp/ui/#search) for the region you want data for. You can do this using the `--region` flag.
+When using Ember, you will need to pass either an [Alpha-2 or Alpha-3 ISO country code](https://www.iso.org/obp/ui/#search). You can do this using the `--region` flag.
 
 For example, the code below returns data for Taiwan.
 
@@ -91,22 +91,22 @@ grid-intensity --provider=watttime.org --region=CAISO_NORTH
 
 ### Limitations
 
-Each region will return a `percent` field. This value represents the relative realtime marginal emissions intensity for the _past month_.
+Each region will return a `percent` field. This value represents the relative real-time marginal emissions intensity for the _past month_.
 
 If you require Marginal Operating Emissions Rate (MOER) data, this is available for free when querying the `CAISO_NORTH` region but will require a [_WattTime Pro subscription_](https://www.watttime.org/get-the-data/data-plans/) for other regions.
 
 
 ***
 
-## Electrity Map <div class="badge badge-warning gap-2 align-middle">API token required</div>
+## Electricity Map <div class="badge badge-warning gap-2 align-middle">API token required</div>
 
-The Electricity Maps API provides worldwide access to 24/7 grid carbon intensity historically, in real time, and as a forecast for the next 24 hours.
+The Electricity Map API provides worldwide access to 24/7 grid carbon intensity historically, in real time, and as a forecast for the next 24 hours.
 
 `--provider=electricitymap.org`
 
 ### Registration
 
-Before using the Electricy Map integration, you must first [obtain an API key](https://static.electricitymap.org/api/docs/index.html#authentication). This will allow you to access and use their API.
+Before using the Electricity Map integration, you must first [obtain an API key](https://static.electricitymap.org/api/docs/index.html#authentication). This will allow you to access and use their API.
 
 Once you have an Electricity Map API key, you must set the `ELECTRICITY_MAP_API_TOKEN` environment variable. This allows the Grid Intensity CLI to access the Electricity Map API.
 

--- a/src/docs/grid-intensity-cli/grid-intensity-cli.json
+++ b/src/docs/grid-intensity-cli/grid-intensity-cli.json
@@ -1,0 +1,9 @@
+{
+	"tags": ["grid-intensity-cli"],
+	"permalink": "{% if not overridePermalink %}{% generateDocsPath page.filePathStem %}/index.html{% else %}{{ overridePermalink }}{% endif %}",
+	"layout": "layouts/default.njk",
+	"repo": "grid-intensity-cli",
+	"languages": ["go"],
+	"repository": "https://github.com/thegreenwebfoundation/grid-intensity-go",
+	"repoVersion": "0.3.0"
+}

--- a/src/docs/grid-intensity-cli/installation.md
+++ b/src/docs/grid-intensity-cli/installation.md
@@ -1,0 +1,32 @@
+---
+title: Installation
+description: This guide will show you how to install the Grid Intensity CLI using either brew or curl.
+eleventyNavigation:
+  key: install
+  title: Installation
+  order: 2
+---
+
+# Installation
+
+This guide will show you how to install the Grid Intensity CLI using either brew or curl.
+
+## Using brew
+
+To install using [Homebrew](https://brew.sh/), run the following command:
+
+```bash
+brew install thegreenwebfoundation/carbon-aware-tools/grid-intensity
+```
+
+## Using curl
+
+To install using curl, run the following command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thegreenwebfoundation/grid-intensity-go/install-script/install.sh | sudo sh
+```
+
+## Build it yourself
+
+YOu can also manually install the CLI using the latest binary release [available on GitHub](https://github.com/thegreenwebfoundation/grid-intensity-go/releases).

--- a/src/docs/grid-intensity-cli/installation.md
+++ b/src/docs/grid-intensity-cli/installation.md
@@ -29,4 +29,4 @@ curl -fsSL https://raw.githubusercontent.com/thegreenwebfoundation/grid-intensit
 
 ## Build it yourself
 
-YOu can also manually install the CLI using the latest binary release [available on GitHub](https://github.com/thegreenwebfoundation/grid-intensity-go/releases).
+You can also manually install the CLI using the latest binary release [available on GitHub](https://github.com/thegreenwebfoundation/grid-intensity-go/releases).

--- a/src/docs/grid-intensity-cli/installation.md
+++ b/src/docs/grid-intensity-cli/installation.md
@@ -30,3 +30,17 @@ curl -fsSL https://raw.githubusercontent.com/thegreenwebfoundation/grid-intensit
 ## Build it yourself
 
 You can also manually install the CLI using the latest binary release [available on GitHub](https://github.com/thegreenwebfoundation/grid-intensity-go/releases).
+
+Once you have downloaded the tarball, you will need to:
+
+1. Extract the `grid-intensity` binary.
+1. Make it executable.
+1. Move it to somewhere in your path.
+
+For example:
+
+```bash
+tar xzf grid-intensity_0.3.0_Darwin_arm64.tar.gz grid-intensity
+chmod +x grid-intensity
+sudo mv grid-intensity /usr/local/bin/
+```

--- a/src/docs/grid-intensity-cli/overview.md
+++ b/src/docs/grid-intensity-cli/overview.md
@@ -1,0 +1,36 @@
+---
+tags: main
+libraryName: Grid Intensity CLI
+title: Overview
+description: A tool that enables developers and operations teams to surface, track, and understand the carbon intensity of running code.
+eleventyNavigation:
+  key: overview
+  title: Overview
+  order: 1
+---
+
+# Grid Intensity CLI - Overview
+
+The electricity that powers the computers on which our code is run comes from a variety of sources - renewable, low-carbon, and fossil fuel based. We call this the fuel mix, and this fuel mix can impact on the carbon intensity of your code.
+
+The Grid Intensity CLI aims to max information about the carbon intensity of regions around the world more accessible to developers. By doing so, they are better informed to make decisions about where and/or when to run their code.
+
+## What is the Grid Intensity CLI?
+
+A tool that enables developers and operations teams to surface, track, and understand the carbon intensity of running code.
+
+## Why use it?
+
+Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space.
+
+### Moving through time
+
+Sometime code _needs_ to be run in a particular region. In these instances, developers can use grid intensity information to identify periods of low carbon intensity on the grid - meaning that more green or renewable electricity is in the fuel mix. Scheduled jobs, or intensive computational tasks, can then be run during this time. 
+
+### Moving through space
+
+Increasingly, code is deployed to multiple regions around the world. In this scenario, developers can use the Grid Intensity CLI to easily consolidate carbon intensity data for different regions into a single dashboard or dataset.
+
+With this information at hand, they can look for ways to run code in locations with a greener fuel mix. This can even be extended to setting up smarter, carbon aware routing so that more requests are directed towards code running in regions with a lower carbon intensity.
+
+The above a just a few examples of the many and varied ways the Grid Intensity CLI can be used. If you’re using the Grid Intensity CLI in production we’d love to hear how! [Contact us](https://www.thegreenwebfoundation.org/support-form/) via our website.

--- a/src/docs/grid-intensity-cli/overview.md
+++ b/src/docs/grid-intensity-cli/overview.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 # Grid Intensity CLI - Overview
 
-The electricity that powers the computers on which code is run comes from a variety of sources - renewable, low-carbon, and fossil fuel based. We call this the fuel mix, and this fuel mix can impact on the carbon intensity of your code.
+The electricity that powers the computers on which code is run comes from a variety of sources - renewable, low-carbon, and fossil fuel based. We call this the fuel mix. And it's this fuel mix that can influence the carbon intensity of code.
 
 The Grid Intensity CLI aims to make global carbon intensity data more accessible to developers. By doing so, developers can be better informed to make decisions about where and/or when to run their code.
 
@@ -25,12 +25,12 @@ The fuel mix will be different depending when and where you run your code. Becau
 
 ### Moving through time
 
-Sometime code _needs_ to be run in a particular region. In these instances, developers can use grid intensity information to identify periods of low carbon intensity. These are periods when more green or renewable electricity is in the fuel mix. Scheduled jobs, or heavy computational tasks, can then be run during these time, making them less carbon intensive.
+Sometime code _needs_ to be run in a particular region. In these instances, developers can use grid information to identify periods of low carbon intensity. These are times when more green or renewable electricity is in the fuel mix. Scheduled jobs or heavy computational tasks can then be run during these time, making them less carbon intensive.
 
 ### Moving through space
 
 Increasingly, code is deployed to multiple regions around the world. In this scenario, developers can use the Grid Intensity CLI to easily consolidate carbon intensity data for different regions into a single dashboard or dataset.
 
-With this information at hand, they can look for ways to run code in locations with a greener fuel mix. This can be extended to smarter, carbon aware routing so that more requests are directed towards code running in regions with a lower carbon intensity.
+With this information at hand, they can look for ways to run code in locations with a greener fuel mix. This can be extended to smarter, carbon-aware routing so that more requests are directed to code running in regions with a lower carbon intensity.
 
 The above a just a few examples of the many and varied ways the Grid Intensity CLI can be used. If you’re using the Grid Intensity CLI in production we’d love to hear how! [Contact us](https://www.thegreenwebfoundation.org/support-form/) via our website.

--- a/src/docs/grid-intensity-cli/overview.md
+++ b/src/docs/grid-intensity-cli/overview.md
@@ -2,7 +2,7 @@
 tags: main
 libraryName: Grid Intensity CLI
 title: Overview
-description: A tool that enables developers and operations teams to surface, track, and understand the carbon intensity of running code.
+description: A tool that enables developers and operations teams to surface, monitor, and understand the carbon intensity of the code they run.
 eleventyNavigation:
   key: overview
   title: Overview
@@ -11,26 +11,26 @@ eleventyNavigation:
 
 # Grid Intensity CLI - Overview
 
-The electricity that powers the computers on which our code is run comes from a variety of sources - renewable, low-carbon, and fossil fuel based. We call this the fuel mix, and this fuel mix can impact on the carbon intensity of your code.
+The electricity that powers the computers on which code is run comes from a variety of sources - renewable, low-carbon, and fossil fuel based. We call this the fuel mix, and this fuel mix can impact on the carbon intensity of your code.
 
-The Grid Intensity CLI aims to max information about the carbon intensity of regions around the world more accessible to developers. By doing so, they are better informed to make decisions about where and/or when to run their code.
+The Grid Intensity CLI aims to make global carbon intensity data more accessible to developers. By doing so, developers can be better informed to make decisions about where and/or when to run their code.
 
 ## What is the Grid Intensity CLI?
 
-A tool that enables developers and operations teams to surface, track, and understand the carbon intensity of running code.
+It is a tool that enables developers and operations teams to surface, monitor, and understand the carbon intensity of the code they run.
 
 ## Why use it?
 
-Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space.
+The fuel mix will be different depending when and where you run your code. Because of this, you can influence the carbon intensity of the code you write by moving it through time and space.
 
 ### Moving through time
 
-Sometime code _needs_ to be run in a particular region. In these instances, developers can use grid intensity information to identify periods of low carbon intensity on the grid - meaning that more green or renewable electricity is in the fuel mix. Scheduled jobs, or intensive computational tasks, can then be run during this time. 
+Sometime code _needs_ to be run in a particular region. In these instances, developers can use grid intensity information to identify periods of low carbon intensity. These are periods when more green or renewable electricity is in the fuel mix. Scheduled jobs, or heavy computational tasks, can then be run during these time, making them less carbon intensive.
 
 ### Moving through space
 
 Increasingly, code is deployed to multiple regions around the world. In this scenario, developers can use the Grid Intensity CLI to easily consolidate carbon intensity data for different regions into a single dashboard or dataset.
 
-With this information at hand, they can look for ways to run code in locations with a greener fuel mix. This can even be extended to setting up smarter, carbon aware routing so that more requests are directed towards code running in regions with a lower carbon intensity.
+With this information at hand, they can look for ways to run code in locations with a greener fuel mix. This can be extended to smarter, carbon aware routing so that more requests are directed towards code running in regions with a lower carbon intensity.
 
 The above a just a few examples of the many and varied ways the Grid Intensity CLI can be used. If you’re using the Grid Intensity CLI in production we’d love to hear how! [Contact us](https://www.thegreenwebfoundation.org/support-form/) via our website.

--- a/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
@@ -1,6 +1,6 @@
 ---
 title: Exporting grid intensity data
-description: In this tutorial you will use the Grid Intensity CLI exporter to start a Prometheus exporter with carbon intensity metrics.
+description: In this tutorial you will use the Grid Intensity CLI exporter to start a Prometheus server exporting carbon intensity metrics.
 eleventyNavigation:
   key: export-grid-intensity
   title: Exporting grid intensity data
@@ -12,9 +12,9 @@ eleventyNavigation:
 
 ## Overview
 
-Exporting grid intensity data allows you and your code to respond to changes in grid intensity over time. It also allows developers to create dashboards and monitor tools to visualise grid intensity data, making it easier for non-technical teams to consume.
+Exporting grid intensity data allows you and your code to respond to changes in grid intensity over time. It also allows developers to create dashboards and monitoring tools that visualise grid intensity data, making it easier for non-technical teams to consume.
 
-In this tutorial, you will use the Grid Intensity CLI `exporter` command to start a Prometheus exporter with carbon intensity metrics.
+In this tutorial, you will use the Grid Intensity CLI `exporter` command to start a Prometheus server exporting carbon intensity metrics.
 
 ## Before starting
 
@@ -29,7 +29,7 @@ In this tutorial we will be using the [UK Carbon Intensity API](https://carbonin
 
 ## Using the `exporter` command
 
-Let's use the `exporter` command to start a [Prometheus](https://prometheus.io/) exporter on localhost port 8000. There is no need to be familiar with Prometheus for the purposes of this tutorial.
+Let's use the `exporter` command to start a [Prometheus](https://prometheus.io/) server on localhost port 8000. There is no need to be familiar with Prometheus for the purposes of this tutorial.
 
 Running the command below will start the exporter.
 
@@ -46,15 +46,15 @@ Using provider "carbonintensity.org.uk" with region "UK"
 Metrics available at :8000/metrics
 ```
 
-Now, if we visit `localhost:8000/metrics` in our browser we will be presented with a page full of data and stats.
+Now, if you visit `localhost:8000/metrics` in our browser we will be presented with a page full of data and stats.
 
 ## Extracting the relevant data
 
-The Prometheus exporter which we have running on `localhost:8000/metrics` exposes a lot of data. For our purposes, we are interested in the grid intensity data that has been returned from the UK Carbon Intensity API.
+The Prometheus exporter which we have running on `localhost:8000/metrics` exposes _a lot_ of data. For our purposes, we are interested in the grid intensity data that has been returned from the UK Carbon Intensity API.
 
 In this tutorial we'll use the `curl` command in our terminal to fetch this data. In reality, you would add the Prometheus server as a data source to a tool like Grafana.
 
-Ensure that your Prometheus server is still running at `localhost:8000/metrics`, then run the following command.
+Ensure that your Prometheus server is still running at `localhost:8000/metrics`, then run the following command in your terminal.
 
 ```bash
 curl -s http://localhost:8000/metrics | grep grid
@@ -65,10 +65,10 @@ curl -s http://localhost:8000/metrics | grep grid
 grid_intensity_carbon_average{provider="carbonintensity.org.uk",region="UK",units="gCO2 per kWh"} 100
 ```
 
-Here we can see that the current average grid intensity data in the UK is 100. 
+Here we can see that the current average grid intensity data in the UK is `100`. 
 
 <div class="alert alert-info">
-  <p>Data from the UK Carbon Intensity API is updated every 30 minutes. So, if you were to leave the server running, and rerun the above command at a later time then you should see a different grid intensity value.</p>
+  <p>Data from the UK Carbon Intensity API is updated every 30 minutes. So, if you were to leave the server running, and rerun the above command at a later time then you should see a different grid intensity value returned.</p>
 </div>
 
 ## Wrapping up

--- a/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
@@ -52,7 +52,9 @@ Now, if we visit `localhost:8000/metrics` in our browser we will be presented wi
 
 The Prometheus exporter which we have running on `localhost:8000/metrics` exposes a lot of data. For our purposes, we are interested in the grid intensity data that has been returned from the UK Carbon Intensity API.
 
-In this tutorial we'll use the `curl` command in our terminal to fetch this data. Ensure that your Prometheus server is still running at `localhost:8000/metrics`, then run the following command.
+In this tutorial we'll use the `curl` command in our terminal to fetch this data. In reality, you would add the Prometheus server as a data source to a tool like Grafana.
+
+Ensure that your Prometheus server is still running at `localhost:8000/metrics`, then run the following command.
 
 ```bash
 curl -s http://localhost:8000/metrics | grep grid
@@ -65,14 +67,13 @@ grid_intensity_carbon_average{provider="carbonintensity.org.uk",region="UK",unit
 
 Here we can see that the current average grid intensity data in the UK is 100. 
 
-Data from the UK Carbon Intensity API is updated every 30 minutes. So, if you were to leave the server running, and rerun the above command at a later time then you should see a different grid intensity value.
-
 <div class="alert alert-info">
-  <p>In reality you would add the Prometheus server as a data source to a tool like Grafana.</p>
+  <p>Data from the UK Carbon Intensity API is updated every 30 minutes. So, if you were to leave the server running, and rerun the above command at a later time then you should see a different grid intensity value.</p>
 </div>
 
 ## Wrapping up
 
 Now you know how to use the `exporter` command to expose grid intensity on a local server. From here you can:
 
-- 
+- Use Docker to [deploy the exporter](https://github.com/thegreenwebfoundation/grid-intensity-go#docker-image) to a [Kubernetes](https://github.com/thegreenwebfoundation/grid-intensity-go#kubernetes) or [Nomad](https://github.com/thegreenwebfoundation/grid-intensity-go#nomad) cluster.
+- Use the Prometheus exporter as a data source for a [Grafana visualisation](https://prometheus.io/docs/visualization/grafana/).

--- a/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/export-grid-intensity.md
@@ -1,0 +1,78 @@
+---
+title: Exporting grid intensity data
+description: In this tutorial you will use the Grid Intensity CLI exporter to start a Prometheus exporter with carbon intensity metrics.
+eleventyNavigation:
+  key: export-grid-intensity
+  title: Exporting grid intensity data
+  # parent: overview
+  sectionTitle: Tutorials
+  order: 20
+---
+# {{ title }}
+
+## Overview
+
+Exporting grid intensity data allows you and your code to respond to changes in grid intensity over time. It also allows developers to create dashboards and monitor tools to visualise grid intensity data, making it easier for non-technical teams to consume.
+
+In this tutorial, you will use the Grid Intensity CLI `exporter` command to start a Prometheus exporter with carbon intensity metrics.
+
+## Before starting
+
+Ensure that you have the [Grid Intensity CLI installed](/grid-intensity-cli/installation) locally.
+
+## Learning goals
+
+- How to use the Grid Intensity CLI `exporter` command.
+- How to extract grid intensity data from the export.
+
+In this tutorial we will be using the [UK Carbon Intensity API](https://carbonintensity.org.uk/) provider integration. We will use the Grid Intensity CLI to export data for the United Kingdom.
+
+## Using the `exporter` command
+
+Let's use the `exporter` command to start a [Prometheus](https://prometheus.io/) exporter on localhost port 8000. There is no need to be familiar with Prometheus for the purposes of this tutorial.
+
+Running the command below will start the exporter.
+
+```bash
+grid-intensity exporter --provider=carbonintensity.org.uk --region=UK
+```
+
+Here, we have used the `--provider` flag to set the UK Carbon Intensity API as our data source. We also use the `--region` flag to tell the exporter what region we want to get data for.
+
+When the `exporter` command runs successfully, you will see the following message:
+
+```bash
+Using provider "carbonintensity.org.uk" with region "UK"
+Metrics available at :8000/metrics
+```
+
+Now, if we visit `localhost:8000/metrics` in our browser we will be presented with a page full of data and stats.
+
+## Extracting the relevant data
+
+The Prometheus exporter which we have running on `localhost:8000/metrics` exposes a lot of data. For our purposes, we are interested in the grid intensity data that has been returned from the UK Carbon Intensity API.
+
+In this tutorial we'll use the `curl` command in our terminal to fetch this data. Ensure that your Prometheus server is still running at `localhost:8000/metrics`, then run the following command.
+
+```bash
+curl -s http://localhost:8000/metrics | grep grid
+
+# Returns
+# HELP grid_intensity_carbon_average Average carbon intensity for the electricity grid in this region.
+# TYPE grid_intensity_carbon_average gauge
+grid_intensity_carbon_average{provider="carbonintensity.org.uk",region="UK",units="gCO2 per kWh"} 100
+```
+
+Here we can see that the current average grid intensity data in the UK is 100. 
+
+Data from the UK Carbon Intensity API is updated every 30 minutes. So, if you were to leave the server running, and rerun the above command at a later time then you should see a different grid intensity value.
+
+<div class="alert alert-info">
+  <p>In reality you would add the Prometheus server as a data source to a tool like Grafana.</p>
+</div>
+
+## Wrapping up
+
+Now you know how to use the `exporter` command to expose grid intensity on a local server. From here you can:
+
+- 

--- a/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
@@ -1,0 +1,110 @@
+---
+title: Getting grid intensity for a region
+description: In this tutorial you will use the Grid Intensity CLI to get both historical and near-realtime data for a region.
+eleventyNavigation:
+  key: getting-grid-intensity
+  title: Getting grid intensity for a region
+  # parent: overview
+  sectionTitle: Tutorials
+  order: 10
+---
+# {{ title }}
+
+## Overview
+
+Being aware of the grid intensity for the regions in which your code runs allows you to make better informed decisions about where and/or when to run it.
+
+In this tutorial, you will use the Grid Intensity CLI to:
+
+1. Get historical emissions intensity data for a region.
+1. Change data providers, and
+1. Get near-realtime grid intensity data for a region.
+
+## Before starting
+
+Ensure that you have the [Grid Intensity CLI installed](/grid-intensity-cli/installation) locally.
+
+## Learning goals
+
+- How to use the Grid Intensity CLI historical and near-realtime data.
+- How to change providers using the CLI.
+
+In this tutorial we will be using the [Ember](https://ember-climate.org/) and [WattTime](https://www.watttime.org/) provider integrations. We will use the Grid Intensity CLI to get data for the country of Portugal.
+
+## Get grid intensity for the last calendar year
+
+To being with, let's get grid intensity data for the last calendar year. By doing this, we can get a snapshot of a region's carbon intensity profile.
+
+Once you have installed the [Grid Intensity CLI](/grid-intensity-cli/installation), run the following command in your terminal.
+
+```bash
+grid-intensity --region=PT
+```
+
+The command above uses the Ember dataset - the default integration for the Grid Intensity CLI. We have used the `--region` flag to request data for Portugal (`PT`).
+
+<div class="alert alert-info">
+  <div>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+    <span>When using Ember, you will need to pass either an <a href="https://www.iso.org/obp/ui/#search">Alpha-2 or Alpha-3 ISO country code</a> for the region you want data for.</span>
+  </div>
+</div>
+
+Running the command above will return data that looks similar to the snippet below.
+
+```json
+{
+	"country_code_iso_2": "PT",
+	"country_code_iso_3": "PRT",
+	"country_or_region": "Portugal",
+	"year": 2021,
+	"latest_year": 2021,
+	"emissions_intensity_gco2_per_kwh": 222.632
+}
+```
+
+Here, we are interested in the value of the `emissions_intensity_gco2_per_kwh` field. This shows us how many grams of CO2 were emitted per kilowatt-hour of electricity generated in a region. The closer to zero this number is, the cleaner a region's electric grid is.
+
+## Get near realtime grid intensity data
+
+Having historical data for a region is a great first step. But, if we want our code to be _carbon aware_ then we'll need to get more up-to-date information.
+
+To do this, we will use the WattTime API integration.
+
+<aside class="alert  alert-warning"><div>
+<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+	<p>Please note that you will need to first create a free WattTime user account to use their API.</p>
+</div></aside>
+
+{% include 'snippets/watttime-registration.md' %}
+
+### Using WattTime with the Grid Intensity CLI
+
+Once you have setup your WattTime account, you can run the command below in your terminal.
+
+```bash
+grid-intensity --provider=watttime.org --region=PT
+```
+
+Here, we use the `--provider` flag to let the CLI know that we want to use the WattTime API to fetch data. As before, we have set the `--region` flag to return data for Portugal (`PT`).
+
+Running the command above will return data that looks similar to the snippet below.
+
+```json
+{
+	"ba": "PT",
+	"freq": "300",
+	"moer": "",
+	"percent": "81",
+	"point_time": "2022-07-28T06:00:00Z"
+}
+```
+
+Here, we are interested in the value of the `percent` field. This value represents the relative realtime marginal emissions intensity for the _past month_. A lower value here represents a cleaner electricity grid.
+
+## Wrapping up
+
+Now you know how to use different providers to fetch regional grid intensity data. From here you can:
+
+- Try some of the [other provider integrations](/grid-intensity-cli/explainer/providers/).
+- [Export grid intensity information](/grid-intensity-cli/tutorials/export-grid-intensity) to be used by other tools.

--- a/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
@@ -1,6 +1,6 @@
 ---
 title: Getting grid intensity for a region
-description: In this tutorial you will use the Grid Intensity CLI to get both historical and near-realtime data for a region.
+description: In this tutorial you will use the Grid Intensity CLI to get both historical and near real-time data for a region.
 eleventyNavigation:
   key: getting-grid-intensity
   title: Getting grid intensity for a region
@@ -12,13 +12,13 @@ eleventyNavigation:
 
 ## Overview
 
-Being aware of the grid intensity for the regions in which your code runs allows you to make better informed decisions about where and/or when to run it.
+Knowing the grid intensity for the regions in which your code runs allows you to make better informed decisions about where and/or when to run it.
 
 In this tutorial, you will use the Grid Intensity CLI to:
 
-1. Get historical emissions intensity data for a region.
+1. Get historical intensity data for a region.
 1. Change data providers, and
-1. Get near-realtime grid intensity data for a region.
+1. Get near 0real-time grid intensity data for a region.
 
 ## Before starting
 
@@ -26,8 +26,9 @@ Ensure that you have the [Grid Intensity CLI installed](/grid-intensity-cli/inst
 
 ## Learning goals
 
-- How to use the Grid Intensity CLI historical and near-realtime data.
+- How to use the Grid Intensity CLI to get historical and near real-time data.
 - How to change providers using the CLI.
+- How to set a region using the CLI.
 
 In this tutorial we will be using the [Ember](https://ember-climate.org/) and [WattTime](https://www.watttime.org/) provider integrations. We will use the Grid Intensity CLI to get data for the country of Portugal.
 
@@ -63,9 +64,9 @@ Running the command above will return data that looks similar to the snippet bel
 }
 ```
 
-Here, we are interested in the value of the `emissions_intensity_gco2_per_kwh` field. This shows us how many grams of CO2 were emitted per kilowatt-hour of electricity generated in a region. The closer to zero this number is, the cleaner a region's electric grid is.
+Here, we are interested in the value of the `emissions_intensity_gco2_per_kwh` field. This shows us how many grams of CO2 were emitted per kilowatt-hour of electricity generated in Portugal during 2021. The closer this number is to zero, the cleaner a region's grid is.
 
-## Get near realtime grid intensity data
+## Get near real-time grid intensity data
 
 Having historical data for a region is a great first step. But, if we want our code to be _carbon aware_ then we'll need to get more up-to-date information.
 
@@ -73,7 +74,7 @@ To do this, we will use the WattTime API integration.
 
 <aside class="alert  alert-warning"><div>
 <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-	<p>Please note that you will need to first create a free WattTime user account to use their API.</p>
+	<p>Please note that you will first need to create a free WattTime user account to use their API.</p>
 </div></aside>
 
 {% include 'snippets/watttime-registration.md' %}
@@ -86,7 +87,7 @@ Once you have setup your WattTime account, you can run the command below in your
 grid-intensity --provider=watttime.org --region=PT
 ```
 
-Here, we use the `--provider` flag to let the CLI know that we want to use the WattTime API to fetch data. As before, we have set the `--region` flag to return data for Portugal (`PT`).
+Here, we use the `--provider` flag to let the CLI know to fetch data from the WattTime API. As before, we have set the `--region` flag to return data for Portugal (`PT`).
 
 Running the command above will return data that looks similar to the snippet below.
 
@@ -100,7 +101,7 @@ Running the command above will return data that looks similar to the snippet bel
 }
 ```
 
-Here, we are interested in the value of the `percent` field. This value represents the relative realtime marginal emissions intensity for the _past month_. A lower value here represents a cleaner electricity grid.
+Here, we are interested in the value of the `percent` field. This value represents the relative real-time marginal emissions intensity for the _past month_. A lower value here represents a cleaner electricity grid.
 
 ## Wrapping up
 

--- a/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
+++ b/src/docs/grid-intensity-cli/tutorials/getting-grid-intensity.md
@@ -18,7 +18,7 @@ In this tutorial, you will use the Grid Intensity CLI to:
 
 1. Get historical intensity data for a region.
 1. Change data providers, and
-1. Get near 0real-time grid intensity data for a region.
+1. Get near real-time grid intensity data for a region.
 
 ## Before starting
 

--- a/src/index.md
+++ b/src/index.md
@@ -17,7 +17,7 @@ Currently, the libraries below have some documentation you can reference:
  
 </div>
 
-<ul class="list-disc px-0 prose-lg">
+<ul class="list-disc px-0 prose-lg flex gap-6 flex-wrap">
 {%- for main in collections.main -%}
             <li class="card w-full md:w-96 bg-base-100 shadow-xl">
              <div class="card-body">


### PR DESCRIPTION
Add an initial set of documentation introducting and explaing the Grid Intensity CLI.

This PR will include:

- [ ] Overview
- [ ] Installation
- [ ] Explainer: Information about providers
- [ ] Tutorial: Getting grid intensity information for a region
- [ ] Tutorial: Exporting grid intensity data