### PR TITLE
update co2js docs for v0.10.0

### DIFF
--- a/src/docs/co2js/co2js.json
+++ b/src/docs/co2js/co2js.json
@@ -5,5 +5,5 @@
 	"repo": "co2js",
 	"languages": ["javascript"],
 	"repository": "https://github.com/thegreenwebfoundation/co2.js",
-	"repoVersion": "0.9.0"
+	"repoVersion": "0.10.0"
 }

--- a/src/docs/co2js/installation.md
+++ b/src/docs/co2js/installation.md
@@ -27,10 +27,7 @@ You can import the CO2.js library into projects using Skypack.
 import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
 ```
 
-
 ### Build it yourself
-
-{% betaCodeWarning 'https://github.com/thegreenwebfoundation/co2.js/pull/92' %}
 
 You can also build the CO2.js library from the source code. To do this:
 

--- a/src/docs/co2js/tutorials/getting-started-browser.md
+++ b/src/docs/co2js/tutorials/getting-started-browser.md
@@ -47,7 +47,8 @@ Here's some boilerplate code to get started with. Copy this into the `index.html
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My CO2.js calculator</title>
 
-    <script>
+    <script type="module">
+      <!-- Our code will go here -->
     </script>
 </head>
 <body>

--- a/src/docs/co2js/tutorials/getting-started-browser.md
+++ b/src/docs/co2js/tutorials/getting-started-browser.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting started: In the browser"
 description: "In this tutorial, you will use CO2.js in the browser to calculate the CO2 emissions of transferring 1 gigabyte (GB) of data."
-relatedPR: https://github.com/thegreenwebfoundation/co2.js/pull/92
+relatedPR: 
 eleventyNavigation:
   key: getting-started-browser
   title: "Getting started: In the browser"
@@ -66,7 +66,7 @@ So that we can get to writing code sooner, we will use [Skypack](https://www.sky
 In the `index.html` file you just created, add the following line inside the `<script>` block in the head of the page. 
 
 ```js
-import tgwf from 'https://cdn.skypack.dev/@tgwf/co2@beta';
+import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
 ```
 
 ## Calculating emissions per byte
@@ -104,7 +104,7 @@ When you're done, the `<script>` block should look like this:
 
 ```html
 <script type="module">
-  import tgwf from 'https://cdn.skypack.dev/@tgwf/co2@beta';
+  import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
   const emissions = new tgwf.co2()
   const bytesSent = (1000 * 1000 * 1000) // 1GB expressed in bytes
   const greenHost = false // Is the data transferred from a green host?


### PR DESCRIPTION
This updates the documentation for CO2.js to reflect the merged PR for v0.10.0. https://github.com/thegreenwebfoundation/co2.js/pull/92

The updates remove references to the PR, as well as references to the `@beta` NPM package.