### PR TITLE
Co2js v0.11.1 update

### DIFF
--- a/src/docs/co2js/data.md
+++ b/src/docs/co2js/data.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 Sourcing carbon intensity data shouldn’t be the remit of developers. For that reason, CO2.js now includes yearly average grid intensity data from [Ember](https://ember-climate.org/data/data-explorer/), as well as marginal intensity data from the [UNFCCC](https://unfccc.int/) (United Nations Framework Convention on Climate Change).
 
-## Average and mariginal intensity explained
+## Average and marginal intensity explained
 
 Average emissions intensity uses the fuel mix of the entire electricity grid and can be used to derive estimates for the carbon footprint of a digital product or service. You’ll see average intensity used in the majority of carbon reporting standards and tooling. This makes it useful if you were to use CO2.js to feed in data to other carbon reporting tools.
 

--- a/src/docs/co2js/data.md
+++ b/src/docs/co2js/data.md
@@ -27,7 +27,7 @@ You can also import annual, country-level marginal or average grid intensity dat
 
 ```js
 import { averageIntensity } from '@tgwf/co2';
-const { data, type, source, year } = averageIntensity;
+const { data, type, year } = averageIntensity;
 
 const { AUS } = data;
 console.log({ AUS })
@@ -37,7 +37,7 @@ Likewise, if you want to use annual marginal intensity for Australia:
 
 ```js
 import { marginalIntensity } from '@tgwf/co2';
-const { data, type, source, year } = marginalIntensity;
+const { data, type, year } = marginalIntensity;
 
 const { AUS } = data;
 console.log({ AUS })

--- a/src/docs/co2js/installation.md
+++ b/src/docs/co2js/installation.md
@@ -13,7 +13,7 @@ This guide will show you how to quickly get started with CO2.js in a variety of 
 
 ## Using NPM
 
-You can install CO2.js as a dependency for your projects using NPM.
+If you're working in a project that already uses NPM, then you can install CO2.js as a dependency.
 
 ```bash
 npm install @tgwf/co2
@@ -21,7 +21,7 @@ npm install @tgwf/co2
 
 ## Using Skypack
 
-You can import the CO2.js library into projects using Skypack.
+To get started with CO2.js quickly in the browser, you can import the library using Skypack.
 
 ```js
 import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
@@ -29,7 +29,7 @@ import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
 
 ## Using a JS CDN
 
-You can get the latest version of CO2.js using one of the content delivery networks below.
+You can get the latest version of CO2.js using one of the content delivery networks below. This comes in handy if you want to use CO2.js in projects that aren't using Node JS or NPM.
 
 ### jsDelivr
 
@@ -49,7 +49,7 @@ You can find the package at [https://unpkg.com/browse/@tgwf/co2@latest/](https:/
 
 ## Build it yourself
 
-You can also build the CO2.js library from the source code. To do this:
+You can also build the CO2.js library from the source code. This allows you to make code changes should you need to do so. To build CO2.js:
 
 1. Go to the [CO2.js repository](https://github.com/thegreenwebfoundation/co2.js) on GitHub.
 1. Clone or fork the repository.

--- a/src/docs/co2js/installation.md
+++ b/src/docs/co2js/installation.md
@@ -27,9 +27,17 @@ To get started with CO2.js quickly in the browser, you can import the library us
 import tgwf from 'https://cdn.skypack.dev/@tgwf/co2';
 ```
 
-## Using a JS CDN
+## Using a CDN
 
 You can get the latest version of CO2.js using one of the content delivery networks below. This comes in handy if you want to use CO2.js in projects that aren't using Node JS or NPM.
+
+### Unpkgd
+
+You can find the package at [https://unpkg.com/browse/@tgwf/co2@latest/](https://unpkg.com/browse/@tgwf/co2@latest/).
+
+- CommonJS compatible build `https://unpkg.com/@tgwf/co2@latest/dist/cjs/index-node.min.js`
+- ES Modules compatible build `https://unpkg.com/@tgwf/co2@latest/dist/esm/index.js`
+- IIFE compatible build `https://unpkg.com/@tgwf/co2@latest/dist/iife/index.js`
 
 ### jsDelivr
 
@@ -39,13 +47,6 @@ You can find the package at [https://www.jsdelivr.com/package/npm/@tgwf/co2](htt
 - ES Modules compatible build `https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/esm/index.js`
 - IIFE compatible build `https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js`
 
-### Unpkgd
-
-You can find the package at [https://unpkg.com/browse/@tgwf/co2@latest/](https://unpkg.com/browse/@tgwf/co2@latest/).
-
-- CommonJS compatible build `https://unpkg.com/@tgwf/co2@latest/dist/cjs/index-node.min.js`
-- ES Modules compatible build `https://unpkg.com/@tgwf/co2@latest/dist/esm/index.js`
-- IIFE compatible build `https://unpkg.com/@tgwf/co2@latest/dist/iife/index.js`
 
 ## Build it yourself
 


### PR DESCRIPTION
This update reflects changes made to the grid intensity data output in https://github.com/thegreenwebfoundation/co2.js/pull/112.
It also includes a small typo fix.