### PR TITLE
Fix "Greenchek" typo

### DIFF
--- a/src/docs/api/greencheck/greencheck.json
+++ b/src/docs/api/greencheck/greencheck.json
@@ -2,7 +2,7 @@
 	"tags": [
 		"greencheck"
 	],
-	"name": "Greenchek API",
+	"name": "Greencheck API",
 	"permalink": "{% if not overridePermalink %}{% generateDocsPath page.filePathStem %}/index.html{% else %}{{ overridePermalink }}{% endif %}",
 	"layout": "layouts/doc.njk",
 	"repoVersion": "3",


### PR DESCRIPTION
This caused the text "Do you like Greenchek API?" to appear on pages.