### PR TITLE
fix: overflowing text from badge

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -32,6 +32,7 @@ h4[id],
 h5[id],
 h6[id] {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
   scroll-margin-block-start: 1rem;


### PR DESCRIPTION
# :dizzy: Changelog
:star: Fixes #41 
:star: Wraps badge into the next line when there's a space constraint, else displays the badge adjacent to the title.


### Before
![greenweb](https://github.com/thegreenwebfoundation/developer-docs/assets/22348265/267c908e-282e-4e16-8c16-17e384bf41f4)

### After
![greenweb-fix](https://github.com/thegreenwebfoundation/developer-docs/assets/22348265/f8a1d306-2a7a-4356-ae05-037146b55f34)
