### PR TITLE
Fix #35

### DIFF
--- a/src/docs/co2js/tutorials/check-hosting.md
+++ b/src/docs/co2js/tutorials/check-hosting.md
@@ -4,7 +4,7 @@ description: "In this tutorial, you will install CO2.js in a Node environment. T
 eleventyNavigation:
   key: check-hosting
   title: "Check a domain for green hosting"
-  # parent: overview
+  #     parent: overview
   sectionTitle: Tutorials
   order: 13
 ---
@@ -220,36 +220,36 @@ node hosting.js
 # Output:
 # {
 #   "google.com": {
-# url: 'google.com',
-# hosted_by: 'Google Inc.',
-# hosted_by_website: 'https://www.google.com',
-# partner: null,
-# green: true,
-# hosted_by_id: 595,
-# modified: '2024-05-02T06:01:59',
-# supporting_documents: [
-#   {
-#    id: 108,
-#     title: 'Sustainability at Google',
-#     link: 'https://sustainability.google'
+#     url: 'google.com',
+#     hosted_by: 'Google Inc.',
+#     hosted_by_website: 'https://www.google.com',
+#     partner: null,
+#     green: true,
+#     hosted_by_id: 595,
+#     modified: '2024-05-02T06:01:59',
+#     supporting_documents: [
+#     {
+#       id: 108,
+#       title: 'Sustainability at Google',
+#       link: 'https://sustainability.google'
+#     },
+#     {
+#       id: 139,
+#       title: 'Independent verification of Google 2020 Reporting',
+#       link: 'https://s3.nl-ams.scw.cloud/tgwf-web-app-live/uploads/Google_Cloud_-_3degrees_cloud_services_review_statement_final.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCWT1WBAW6NZ5SW5GYJ8%2F20240502%2Fnl-ams%2Fs3%2Faws4_request&X-Amz-Date=20240502T071323Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=1bc5b6f5bbe461b13fb694a7787fede307226386891d0b87ac1914fa95a27684'
+#     },
+#     ... results truncated for readability
+#     ]
 #   },
-#   {
-#     id: 139,
-#     title: 'Independent verification of Google 2020 Reporting',
-#     link: 'https://s3.nl-ams.scw.cloud/tgwf-web-app-live/uploads/Google_Cloud_-_3degrees_cloud_services_review_statement_final.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCWT1WBAW6NZ5SW5GYJ8%2F20240502%2Fnl-ams%2Fs3%2Faws4_request&X-Amz-Date=20240502T071323Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=1bc5b6f5bbe461b13fb694a7787fede307226386891d0b87ac1914fa95a27684'
-#   },
-#   ... results truncated for readability
-# ]
+#   "pchome.com": {
+#       url: "pchome.com",
+#       hosted_by: null,
+#       hosted_by_website: null,
+#       partner: null,
+#       green: false,
+#       hosted_by_id: null,
+#       modified: "2024-05-02T07:16:10.504512"
 #    },
-#  'pchome.com': {
-#   url: 'pchome.com',
-#   hosted_by: null,
-#   hosted_by_website: null,
-#   partner: null,
-#   green: false,
-#   hosted_by_id: null,
-#   modified: '2024-05-02T07:16:10.504512'
-#   },
 # }
 ```
 

--- a/src/docs/co2js/tutorials/customise-website-carbon-calculations.md
+++ b/src/docs/co2js/tutorials/customise-website-carbon-calculations.md
@@ -88,6 +88,9 @@ Here we have created an object within which we have set some key-values to adjus
   - `dataCenter` <span class="badge align-middle badge-success my-0">Optional</span> – A `number` representing the carbon intensity for the given segment (in grams per kilowatt-hour). Or, an `object`, which contains a key of country and a value that is an Alpha-3 ISO country code.
   - `network` <span class="badge align-middle badge-success my-0">Optional</span> – A `number` representing the carbon intensity for the given segment (in grams per kilowatt-hour). Or, an `object`, which contains a key of country and a value that is an Alpha-3 ISO country code.
 
+<aside class="alert alert-info">
+<p>💡 When the `green` parameter (the 2nd parameter) passed into the `perByteTrace` or `perVisitTrace` function is set to `true`, the grid intensity used for `datacenter` is set to 50 gCO2e/kWh. This value is applied regardless of any other custom value that is set by the user.</p></aside>
+
 We can now use this object to calculate the carbon emissions of a gigabyte, transferred from a regular (not green) host. In the example below, we've used the `perVisitTrace` function.
 
 ```js


### PR DESCRIPTION
Add a note to indicate that when using the `perByteTrace` or `perVisitTrace` functions for the Sustainable Web Design model in CO2.js, the value for datacenter grid intensity is set to 50 gCO2e/kWh if the `green` parameter is set to `true`.