### PR TITLE
Add carbon.txt docs

### DIFF
--- a/src/docs/carbon-txt/carbon-txt.json
+++ b/src/docs/carbon-txt/carbon-txt.json
@@ -1,0 +1,15 @@
+{
+    "tags": [
+        "carbon-txt",
+        "csrd"
+    ],
+    "name": "Carbon.txt",
+    "permalink": "{% if not overridePermalink %}{% generateDocsPath page.filePathStem %}/index.html{% else %}{{ overridePermalink }}{% endif %}",
+    "layout": "layouts/doc.njk",
+    "repo": "carbon.txt",
+    "languages": [
+        "javascript"
+    ],
+    "repository": "https://github.com/thegreenwebfoundation/carbon.txt",
+    "repoVersion": "0.2.0"
+}

--- a/src/docs/carbon-txt/explainer/carbon-txt-validator-architecture.md
+++ b/src/docs/carbon-txt/explainer/carbon-txt-validator-architecture.md
@@ -43,7 +43,7 @@ The validator is designed to work as a single deployable unit. This might be as 
 
 ### Components
 
-![Components - there are multiple components that make up the carbon.txt validator. They are the API & CLI; Carbon.txt Finder; Carbon.txt Parser; CSRD Processor](img/1-c-components.jpg)
+![Components - there are multiple components that make up the carbon.txt validator. They are the API & CLI; Carbon.txt Finder; Carbon.txt Parser; CSRD Processor](https://carbon-txt-validator.readthedocs.io/en/latest/_images/1-c-components.jpg)
 
 The carbon.txt validator is split into a series of components, with clear
 divisions of responsibility
@@ -82,7 +82,7 @@ So, for a CSRD report that is written to fit pre-agreed standards, like being wr
 
 ### Classes
 
-![Classes - The CSRD Processor uses the Arelle third-party library to parse and validate XBRL documents. There can be additional validation rules added to the processor which are run before returning results.](img/1-d-classes.jpg)
+![Classes - The CSRD Processor uses the Arelle third-party library to parse and validate XBRL documents. There can be additional validation rules added to the processor which are run before returning results.](https://carbon-txt-validator.readthedocs.io/en/latest/_images/1-d-classes.jpg)
 
 The In our CSRD Processor uses [Arelle](https://arelle.readthedocs.io/), an open source library for working with XBRL documents, to turn XBRL-formatted CSRD reports into datastructures that can be manipulated in Python, and that can be checked for the existence of specific data points.
 

--- a/src/docs/carbon-txt/explainer/carbon-txt-validator-architecture.md
+++ b/src/docs/carbon-txt/explainer/carbon-txt-validator-architecture.md
@@ -1,0 +1,89 @@
+---
+title: Architecture of the carbon.txt validator
+description: A high-level explanation of the architecture behind the carbon.txt validator.
+eleventyNavigation:
+  key: carbon-txt-validator-architecture
+  # parent: overview
+  title: Architecture of the carbon.txt validator
+  sectionTitle: Explanations
+  order: 30
+---
+
+# {{ title }}
+
+This page provides a high-level explanation of the carbon.txt validator and its architecture.
+
+## What is the carbon.txt validator
+
+The carbon.txt validator is a command-line tool (CLI) as well as a deployable API. The main purpose of the validator is to read the content of carbon.txt files and validate them against a spec defined on [http://carbontxt.org](http://carbontxt.org).
+
+The code for the validator is open source, and can be [found on GitHub](https://github.com/thegreenwebfoundation/carbon-txt-validator). Further, more detailed, documentation can be found at [https://carbon-txt-validator.readthedocs.io/en/latest/](https://carbon-txt-validator.readthedocs.io/en/latest/).
+
+## Carbon.txt validator architecture
+
+### How carbon.txt is designed
+
+The following diagrams use the [C4 model](https://c4model.com/) for describing software architecture to describe how the Carbon.txt validator is designed.
+
+### Context View
+
+![Context - a user sends a domain to lookup to the carbon.txt validator, which then fetches the carbon.txt file from that domain. The validator sends back validation results to the user.](https://carbon-txt-validator.readthedocs.io/en/latest/_images/1-a-context.jpg)
+
+The context view demonstrate how we expect the the validator to be used by end-users.
+
+These might be people using the validator via the [carbon.txt website](https://carbontxt.org/tools/validator), as command line tool, or in a data pipeline,
+
+In all cases the key idea is that the validator is designed to run lookups against a given domain, to find the published sustainability data for later processing.
+
+### Containers
+
+![Containers - a user sends a domain to lookup via a HTTP request. The carbon.txt validator fetches the carbon.txt file from that domain, and also fetches any linked CSRD documents that are references inside that file. The validator sends back results to the user in JSON format.](https://carbon-txt-validator.readthedocs.io/en/latest/_images/1-b-containers.jpg)
+
+The validator is designed to work as a single deployable unit. This might be as a server providing an API, or as part of a batch job, running on a periodically on an existing host.
+
+### Components
+
+![Components - there are multiple components that make up the carbon.txt validator. They are the API & CLI; Carbon.txt Finder; Carbon.txt Parser; CSRD Processor](img/1-c-components.jpg)
+
+The carbon.txt validator is split into a series of components, with clear
+divisions of responsibility
+
+- **Finders**: Finders are responsible for accepting a domain or URI, and
+  resolving it to the final URI where a carbon.txt file is accessible, for
+  fetching and reading.
+- **Parsers**: Parsers are responsible for parsing carbon.txt files, then making
+  sure they valid and conform to the required data schema.
+- **Processors**(s): Processors are responsible for parsing specific kinds of
+  linked documents, and data, and returning a valid data structure.
+
+We cover these in more detail below
+
+#### Finders
+
+A **Finder** is responsible for locating and fetching a files, either from remote sources or from local paths on the same machine. It's the only part of the system that makes outbound network requests. They are expected to make DNS lookups, and HTTPS requests, local path resolution, and they are responsible for handling related retry and failure handling logic.
+
+They are responsible for sending along strings or datastructures to **Parsers** and **Processors**. When links to remote files exist in parsed carbon.txt files, the finders handle finding and fetching too.
+
+The intention is to keep the logic for similar tasks related to finding and retrieving file in one place.
+
+#### Parsers
+
+**Parsers** in this context are primarily responsible for checking that a datastructure, or contents of a retrieved carbon.txt file meet the expected format and structure.
+
+They don't make network requests. Where a carbon.txt file links to specific kinds of resources like CSRD reports, or external webpages, they delegate to the corresponding **Processor** for that kind of resource.
+
+Parsers only work with strings of datastructures and are not responsible for any further IO.
+
+#### Processors
+
+**Processors** are responsible for extracting useable data out of disclosure documents linked in a carbon.txt file. They contain logic specific to a given kind of linked document, and different documents will have different processors.
+
+So, for a CSRD report that is written to fit pre-agreed standards, like being written as an iXBRL document, and following reporting standard like the ESRS and we would have a CSRD processor that relies on software designed to parse and extract this kind of data, like the [open source Arelle XBRL parsing library](https://arelle.readthedocs.io/en/2.36.5/).
+
+### Classes
+
+![Classes - The CSRD Processor uses the Arelle third-party library to parse and validate XBRL documents. There can be additional validation rules added to the processor which are run before returning results.](img/1-d-classes.jpg)
+
+The In our CSRD Processor uses [Arelle](https://arelle.readthedocs.io/), an open source library for working with XBRL documents, to turn XBRL-formatted CSRD reports into datastructures that can be manipulated in Python, and that can be checked for the existence of specific data points.
+
+The validation results are returned in API respones, or the output in CLI commands.

--- a/src/docs/carbon-txt/overview.md
+++ b/src/docs/carbon-txt/overview.md
@@ -22,7 +22,11 @@ It’s a web-first, *connect not collect* style approach, of most benefit to tho
 1. **New standards mean that this data will be comparable, machine-readable, and likely across different parts of the world.** This could make verifying claims and identifying greenwashing easier, if it’s done right.
 1. **Carbon.txt is our open-source project to make this sustainability information easier to discover.** Carbon.txt is a spec that defines predictable, consistent places on any website to publish sustainability data so that both humans and machines can find it.
 
-## Carbon.txt Tools
+## These docs
+
+The documentation on this website is aimed at developers looking to build additional tooling that extends carbon.txt - primarily through plugins and other extensions to the [carbon.txt validator](https://github.com/thegreenwebfoundation/carbon-txt-validator).
+
+## Other Carbon.txt Tools
 
 Below are a collection of tools that you can use to get started creating a carbon.txt file for your organisation, or to check the contents of an existing carbon.txt file.
 

--- a/src/docs/carbon-txt/overview.md
+++ b/src/docs/carbon-txt/overview.md
@@ -1,0 +1,42 @@
+---
+tags: main
+libraryName: Carbon.txt
+title: Overview
+description: carbon.txt makes sustainability data easier to discover and use on the web.
+eleventyNavigation:
+  key: overview
+  title: Overview
+  order: 1
+---
+
+# Carbon.txt - Overview
+
+Carbon.txt is a single place to look on any domain – */carbon.txt* – for public, machine-readable, sustainability data relating to that company.
+
+It’s a web-first, *connect not collect* style approach, of most benefit to those interested in scraping the structured data companies have to publish according to national laws. Designed to be extended by default, we see carbon.txt becoming essential infrastructure for sustainability data services crunching available numbers and sharing the stories it can tell.
+
+## Why carbon.txt?
+
+1. **Discovery of sustainability data continues to be a problem.** Our research with Wikirate made it abundantly clear that without new, webby approaches, sustainability data will continue to be hard to find or out of date.
+1. **Changes in the law mean that lots of firms will need to publish all kinds of sustainability data that previously they didn’t have to.** The law literally says they need to publish this data online, free of charge for the public to see, and there are significant GDPR-scale fees for non-compliance.
+1. **New standards mean that this data will be comparable, machine-readable, and likely across different parts of the world.** This could make verifying claims and identifying greenwashing easier, if it’s done right.
+1. **Carbon.txt is our open-source project to make this sustainability information easier to discover.** Carbon.txt is a spec that defines predictable, consistent places on any website to publish sustainability data so that both humans and machines can find it.
+
+## Carbon.txt Tools
+
+Below are a collection of tools that you can use to get started creating a carbon.txt file for your organisation, or to check the contents of an existing carbon.txt file.
+
+- [Quickstart](https://carbontxt.org/how/digital-services)
+- [File builder](https://carbontxt.org/tools/builder)
+- [Carbon.txt validator](https://carbontxt.org/tools/validator)
+
+## Keep updated
+
+To follow the Grid-aware Websites project, you can:
+
+- <a href="https://www.linkedin.com/company/9184998" class="btn btn-primary">Follow us on LinkedIn</a>
+- <a href="https://www.thegreenwebfoundation.org/newsletter/" class="btn btn-neutral">Subscribe to our montlhy newsletter</a>
+
+## Licenses
+
+The code for Grid-aware Websites core library and plugins are licensed [Apache 2.0](https://github.com/thegreenwebfoundation/grid-aware-websites/blob/main/LICENSE). ([What does this mean?](<https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)>))

--- a/src/docs/carbon-txt/overview.md
+++ b/src/docs/carbon-txt/overview.md
@@ -30,16 +30,51 @@ The documentation on this website is aimed at developers looking to build additi
 
 Below are a collection of tools that you can use to get started creating a carbon.txt file for your organisation, or to check the contents of an existing carbon.txt file.
 
-- [Quickstart](https://carbontxt.org/how/digital-services)
-- [File builder](https://carbontxt.org/tools/builder)
-- [Carbon.txt validator](https://carbontxt.org/tools/validator)
+<div class="alert bg-secondary text-white">
+  <div class="items-start">
+    <div>
+      <h2 class="text-white font-bold my-3 gap-2 flex items-center"><svg xmlns="http://www.w3.org/2000/svg" class="text-white inline flex-shrink-0 w-6 h-6" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="12" cy="12" r="9" />
+  <polyline points="12 7 12 12 15 15" />
+</svg>Quickstart guide?</h2>
+      <p class="text-lg">Learn how to create a carbon.txt file for your organisation, upload it to your domain, and check that it is valid.</p>
+    </div>
+  </div>
+  <div class="flex-none">
+    <a href="https://carbontxt.org/quickstart" class="btn btn-lg btn-black hover:bg-primary">Go to guide</a>
+  </div>
+</div>
+
+<ul class="list-disc px-0 prose-lg flex gap-6 flex-wrap mt-8">
+            <li class="card w-full md:w-96 bg-base-100 shadow-xl not-prose">
+             <div class="card-body not-prose">
+    <h3 class="card-title not-prose">File builder
+    </h3>
+    <span>Create a carbon.txt file for your organisation</span>
+    <div class="card-actions justify-end not-prose">
+      <a href="https://carbontxt.org/tools/builder" class="btn btn-secondary">Use the builder</a>
+    </div>
+  </div>
+                </li>
+            <li class="card w-full md:w-96 bg-base-100 shadow-xl not-prose">
+             <div class="card-body not-prose">
+    <h3 class="card-title not-prose">Validator
+    </h3>
+    <span>Check the syntax of a carbon.txt file and view its content.</span>
+    <div class="card-actions justify-end not-prose">
+      <a href="https://carbontxt.org/tools/validator" class="btn btn-secondary">Use the validator</a>
+    </div>
+  </div>
+                </li>
+</ul>
 
 ## Keep updated
 
 To follow the Grid-aware Websites project, you can:
 
-- <a href="https://www.linkedin.com/company/9184998" class="btn btn-primary">Follow us on LinkedIn</a>
-- <a href="https://www.thegreenwebfoundation.org/newsletter/" class="btn btn-neutral">Subscribe to our montlhy newsletter</a>
+<a href="https://www.linkedin.com/company/9184998" class="btn btn-primary">Follow us on LinkedIn</a>
+<a href="https://www.thegreenwebfoundation.org/newsletter/" class="btn btn-neutral">Subscribe to our montlhy newsletter</a>
 
 ## Licenses
 

--- a/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
+++ b/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
@@ -1,9 +1,9 @@
 ---
-title: "Make a private plugin to use with the carbon.txt CLI"
+title: "Make a private carbon.txt plugin"
 description: "In this tutorial, you will learn how to make a private plugin that can be used with the carbon.txt CLI."
 eleventyNavigation:
   key: make-private-plugin
-  title: "Make a private plugin to use with the carbon.txt CLI"
+  title: "Make a private carbon.txt plugin"
   #     parent: overview
   sectionTitle: Tutorials
   order: 13
@@ -45,7 +45,7 @@ You can check that the carbon.txt validator has been successfully installed by r
 
 It is also worth being aware that under the hood, the carbon.txt validator uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
 
-## Making one-off projects for internal use
+## Making a private plugin
 
 The plugin we are building in this tutorial will:
 
@@ -127,7 +127,7 @@ uv tool run carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir
 
 Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section being the additional information the _our plugin_ is adding to the carbon.txt validator response.
 
-```
+```bash
 Attempting to resolve domain: used-in-tests.carbontxt.org
 Trying a DNS delegated lookup for domain used-in-tests.carbontxt.org
 Checking if a carbon.txt file is reachable at https://used-in-tests.carbontxt.org/carbon.txt

--- a/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
+++ b/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
@@ -1,0 +1,112 @@
+---
+title: "Make a private plugin to use with the carbon.txt CLI"
+description: "In this tutorial, you will learn how to make a private plugin that can be used with the carbon.txt CLI."
+eleventyNavigation:
+  key: make-private-plugin
+  title: "Make a private plugin to use with the carbon.txt CLI"
+  #     parent: overview
+  sectionTitle: Tutorials
+  order: 13
+---
+
+# {{ title }}
+
+## How to implement plugins for the carbon.txt validator
+
+The carbon-txt validator is designed to support extending its functionality via a plugin system, and there are two supported ways to do use it.
+
+1. **Internal plugins for internal use**, via the `--plugins-dir` command line flag
+2. **Publishing plugins for others to use**, as a Python Package
+
+Under the hood, the system uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
+
+By implmenting functions that use the appropriate hook, you can extend the functionlaity of the carbon.txt validator.
+
+A number of well known python projects use this plugin, like [Datasette](https://docs.datasette.io/en/stable/writing_plugins.html#writing-one-off-plugins), [LLM](https://llm.datasette.io/en/stable/plugins/index.html), [Pytest](https://docs.pytest.org/en/latest/how-to/writing_plugins.html#pip-installable-plugins), [Tox](https://tox.wiki/en/latest/plugins.html#) and others. It is well documented and battle tested.
+
+## Making one-off projects for internal use
+
+As an example, carbon.txt files are intended to make the underlying data and supporting evidence for green claims easy to find. So, when a carbon.file links to this data, one thing you might want to do is see if the linked files are publicly accessible online.
+
+One way to do this would be to build a plugin specifically to check that files linked in a carbon.txt file are accessible, by sending a HEAD request over HTTP, to see if ths file is still reachable.
+
+To do this, we need to choose the right "hook" to implement, and we need to decide how we'll make that HTTP request to it.
+
+We know that every `Organisation` using a carbon.txt file making green claims needs to back them up with supporting evidence in the form of `Credentials`, and each `Credential` contains a hyperlink to a file online, at a given `url`.
+
+So, every time we see an `url`, we need to send an HTTP request to see if the file is still reachable. The carbon.txt validator bundles the [httpx](https://www.python-httpx.org/) HTTP client library, so we can use that to send the appropriate request.
+
+### Create a new python file implementing the appropriate hook
+
+Checking the plugin hook list online, we see a `process_document` hook we can uses, that fires for every single `Credential` document linked in a carbon.txt file. So, we use that `hook` to implement.
+
+In a new python file we would implement a method _with the same name as our desired hook_, and with the `@hookimpl` decorator applied to the method. This is how our plugin system knows to run it.
+
+```python
+# saved to ./my_plugins/check_file_online.py
+
+from carbon_txt.plugins import hookimpl
+
+import httpx
+
+@hookimpl
+def process_document(document):
+
+    # we send a HEAD request, as we are not trying to download the file
+    # and check the contents, just see that it's reachable
+    response = httpx.head(document.url, follow_redirects=True)
+
+    if response.status_code == 200:
+        file_online = True
+    else:
+        file_online = False
+
+    results = {
+        "domain": document.domain,
+        "url": document.url,
+        "file_online": file_online
+    }
+    return results
+
+```
+
+### Make sure the file is accessible when calling the carbon-txt command line tool
+
+Now we have a file, we need a way for the carbon.txt validator to find it and run it.
+
+Create a directory, `my_plugins`, in the same directory in a project directory where you expect to run the `carbon-txt` binary .
+
+We then move the file to `my_plugins/check_file_online.py`.
+
+### Run the `carbon-txt` command line tool with the `--plugin-dirs` flag
+
+Finally we run the `carbon-txt` command line tool, with the `--plugin-dirs` flag, and the path to `my_plugins` the directory containing our new plugin.
+
+If we want to check a given domain's carbon.txt file, AND check the linked files ae online, we run our usual command, with the extra flags:
+
+```
+carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir my_plugins/
+```
+
+Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section:
+
+```
+Attempting to resolve domain: used-in-tests.carbontxt.org
+Trying a DNS delegated lookup for domain used-in-tests.carbontxt.org
+Checking if a carbon.txt file is reachable at https://used-in-tests.carbontxt.org/carbon.txt
+New Carbon text file found at: https://used-in-tests.carbontxt.org/carbon.txt
+Carbon.txt file parsed as valid TOML.
+Parsed TOML was recognised as valid Carbon.txt file.
+
+✅ Carbon.txt file syntax is valid!
+
+-------
+
+
+CarbonTxtFile(upstream=Upstream(providers=[]), org=Organisation(disclosures=[Disclosure(domain='used-in-tests.carbontxt.org', doc_type='sustainability-page', url='https://used-in-tests.carbontxt.org/our-climate-record')]))
+-------
+
+Results of processing linked documents in the carbon.txt file:
+
+[{'domain': 'used-in-tests.carbontxt.org', 'url': 'https://used-in-tests.carbontxt.org/our-climate-record', 'file_online': True}]
+```

--- a/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
+++ b/src/docs/carbon-txt/tutorials/make-a-private-plugin.md
@@ -11,84 +11,121 @@ eleventyNavigation:
 
 # {{ title }}
 
-## How to implement plugins for the carbon.txt validator
+## Overview
 
-The carbon-txt validator is designed to support extending its functionality via a plugin system, and there are two supported ways to do use it.
+In this tutorial, you will learn how to make a private plugin that extends the functionality of the carbon.txt validator when used via the command line interface (CLI). For this tutorial, we will create a plugin that checks if the files linked to in a carbon.txt file can be accessed online.
 
-1. **Internal plugins for internal use**, via the `--plugins-dir` command line flag
-2. **Publishing plugins for others to use**, as a Python Package
+### Before you start
 
-Under the hood, the system uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
+Before getting started, it will help to have an understanding of the [carbon.txt syntax](https://carbontxt.org/syntax).
 
-By implmenting functions that use the appropriate hook, you can extend the functionlaity of the carbon.txt validator.
+For the purposes of this tutorial, we will use the [uv Python package manager](https://docs.astral.sh/uv/) to install the carbon.txt validator in a new project. In the next few steps, we will setup our project.
 
-A number of well known python projects use this plugin, like [Datasette](https://docs.datasette.io/en/stable/writing_plugins.html#writing-one-off-plugins), [LLM](https://llm.datasette.io/en/stable/plugins/index.html), [Pytest](https://docs.pytest.org/en/latest/how-to/writing_plugins.html#pip-installable-plugins), [Tox](https://tox.wiki/en/latest/plugins.html#) and others. It is well documented and battle tested.
+1. Follow the [installation steps](https://docs.astral.sh/uv/getting-started/installation/) to install uv on your system.
+2. Create a new folder for the plugin we're building, and navigate into that directory.
+
+```bash
+mkdir carbon-txt-private-plugin
+cd carbon-txt-private-plugin
+```
+
+3. Initiate a project using uv, and specify the Python version to use.
+
+```bash
+uv init --python 3.11
+```
+
+4. Install the carbon.txt validator into the project
+
+```bash
+uv add carbon-txt
+```
+
+You can check that the carbon.txt validator has been successfully installed by running the `uv tool run carbon-txt` command. This will return some documentation for the different commands available with the carbon.txt validator.
+
+It is also worth being aware that under the hood, the carbon.txt validator uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
 
 ## Making one-off projects for internal use
 
-As an example, carbon.txt files are intended to make the underlying data and supporting evidence for green claims easy to find. So, when a carbon.file links to this data, one thing you might want to do is see if the linked files are publicly accessible online.
+The plugin we are building in this tutorial will:
 
-One way to do this would be to build a plugin specifically to check that files linked in a carbon.txt file are accessible, by sending a HEAD request over HTTP, to see if ths file is still reachable.
+1. Read the content of a carbon.txt file that is discovered by the validator
+2. When it finds a `url` property, it will send a HTTP request to that URL to see if the file is reachable.
 
-To do this, we need to choose the right "hook" to implement, and we need to decide how we'll make that HTTP request to it.
+We can do this without installing any other dependencies because the carbon.txt validator bundles the [httpx](https://www.python-httpx.org/) HTTP client library, so we can use that to send the appropriate request.
 
-We know that every `Organisation` using a carbon.txt file making green claims needs to back them up with supporting evidence in the form of `Credentials`, and each `Credential` contains a hyperlink to a file online, at a given `url`.
+### Using the right plugin hook
 
-So, every time we see an `url`, we need to send an HTTP request to see if the file is still reachable. The carbon.txt validator bundles the [httpx](https://www.python-httpx.org/) HTTP client library, so we can use that to send the appropriate request.
+The carbon.txt validator comes with documentation about the different plugin hooks available. This can be found at [https://carbon-txt-validator.readthedocs.io/en/latest/plugin_hooks.html](https://carbon-txt-validator.readthedocs.io/en/latest/plugin_hooks.html).
 
-### Create a new python file implementing the appropriate hook
+From these docs, we can see that there is a hook called `process_document` that fires for every single `Disclosure` object found in a carbon.txt file. The [carbon.txt syntax](https://carbontxt.org/syntax) specifies that each `Disclosure` object must contain a `doc_type` and `url` property. So, for our plugin, we will trigger it to run using the `process_document` hook, and then look for value of the `url` property.
 
-Checking the plugin hook list online, we see a `process_document` hook we can uses, that fires for every single `Credential` document linked in a carbon.txt file. So, we use that `hook` to implement.
+### Writing the code
 
-In a new python file we would implement a method _with the same name as our desired hook_, and with the `@hookimpl` decorator applied to the method. This is how our plugin system knows to run it.
+In our project folder, let's create a new folder called `my_plugins`, and inside that folder create a Python file called `check_file_online.py` and open it in your text editor of choice.
+
+Inside our file, we import `logging`, `httpx`, and the `hookimpl` decorator from the `carbon_txt.plugins` module. We then implement a method _with the same name as our desired hook_ (`process_document`), and add the `@hookimpl` decorator applied to the method. This is how the carbon.txt validator plugin system knows to run it.
+
+The final code for our plugin will look like this:
 
 ```python
 # saved to ./my_plugins/check_file_online.py
 
-from carbon_txt.plugins import hookimpl
+import logging
 
 import httpx
+from carbon_txt.plugins import hookimpl
+
+# every plugin needs a name
+plugin_name = "carbon_txt_check_online"
+
 
 @hookimpl
-def process_document(document):
-
-    # we send a HEAD request, as we are not trying to download the file
-    # and check the contents, just see that it's reachable
+def process_document(document, logs):
+    # we send a HEAD request, as we are not trying to download the file.
+    # and check the contents - we just want to see that it's reachable
     response = httpx.head(document.url, follow_redirects=True)
 
     if response.status_code == 200:
+        logs.append(f"{plugin_name}: File is online: {document.url}")
         file_online = True
     else:
+        logs.append(f"{plugin_name}: File is offline: {document.url}")
         file_online = False
 
-    results = {
-        "domain": document.domain,
+    check_results = {
         "url": document.url,
-        "file_online": file_online
+        "file_online": file_online,
     }
-    return results
+
+    # because processing a document can result in multiple results being
+    # returned we always return a list of results
+    results = [check_results]
+
+    return {
+        # return the logs so we see the output in response seen by the user
+        "logs": logs,
+        # return the name of the plugin, so we can tell the output plugins apart
+        "plugin_name": plugin_name,
+        # return the results of prcoessing the document - in our case a
+        # check to see if it's online
+        "document_results": results,
+    }
+
 
 ```
 
-### Make sure the file is accessible when calling the carbon-txt command line tool
+## Testing that it works
 
-Now we have a file, we need a way for the carbon.txt validator to find it and run it.
+Now we have a file, we can test that it works using the carbon.txt validator. To do this, we will run the carbon.txt validator using `uv` and ask it to validate a domain that contains a carbon.txt file. We will also tell it to use plugins from our newly created `my_plugins` directory.
 
-Create a directory, `my_plugins`, in the same directory in a project directory where you expect to run the `carbon-txt` binary .
+Make sure you run the command below from inside the `carbon-txt-private-plugin` folder that we created at the start of this tutorial.
 
-We then move the file to `my_plugins/check_file_online.py`.
-
-### Run the `carbon-txt` command line tool with the `--plugin-dirs` flag
-
-Finally we run the `carbon-txt` command line tool, with the `--plugin-dirs` flag, and the path to `my_plugins` the directory containing our new plugin.
-
-If we want to check a given domain's carbon.txt file, AND check the linked files ae online, we run our usual command, with the extra flags:
-
-```
-carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir my_plugins/
+```bash
+uv tool run carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir my_plugins/
 ```
 
-Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section:
+Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section being the additional information the _our plugin_ is adding to the carbon.txt validator response.
 
 ```
 Attempting to resolve domain: used-in-tests.carbontxt.org

--- a/src/docs/carbon-txt/tutorials/make-a-public-plugin.md
+++ b/src/docs/carbon-txt/tutorials/make-a-public-plugin.md
@@ -1,91 +1,97 @@
 ---
-title: "Make a public plugin to use with the carbon.txt CLI"
+title: "Make a public carbon.txt plugin"
 description: "In this tutorial, you will learn how to make a public plugin that can be used with the carbon.txt CLI."
 eleventyNavigation:
   key: make-public-plugin
-  title: "Make a public plugin to use with the carbon.txt CLI"
+  title: "Make a public carbon.txt plugin"
   #     parent: overview
   sectionTitle: Tutorials
-  order: 13
+  order: 14
 ---
 
 # {{ title }}
 
-## How to implement plugins for the carbon.txt validator
+## Overview
 
-The carbon-txt validator is designed to support extending its functionality via a plugin system, and there are two supported ways to do use it.
+In this tutorial, you will learn how to make a public plugin that extends the functionality of the carbon.txt validator when used via the command line interface (CLI), as well as how to then publish that plugin so that others can also use it.
 
-1. **Internal plugins for internal use**, via the `--plugins-dir` command line flag
-2. **Publishing plugins for others to use**, as a Python Package
+For this tutorial, we will create a plugin that checks if the files linked to in a carbon.txt file can be accessed online.
 
-Under the hood, the system uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
+### Before you start
 
-By implmenting functions that use the appropriate hook, you can extend the functionlaity of the carbon.txt validator.
+<aside class="alert bg-base-200 text-base-content">
+<p>Before doing this tutorial, we recommend that you complete the <a href="/carbon-txt/tutorials/make-a-private-plugin">Make a private carbon.txt plugin</a> tutorial. This tutorial extends on the code and concepts explained in that tutorial, and so it is recommend you complete that one first.</p>
+</aside>
 
-A number of well known python projects use this plugin, like [Datasette](https://docs.datasette.io/en/stable/writing_plugins.html#writing-one-off-plugins), [LLM](https://llm.datasette.io/en/stable/plugins/index.html), [Pytest](https://docs.pytest.org/en/latest/how-to/writing_plugins.html#pip-installable-plugins), [Tox](https://tox.wiki/en/latest/plugins.html#) and others. It is well documented and battle tested.
+Before getting started, it will help to have an understanding of the [carbon.txt syntax](https://carbontxt.org/syntax).
 
-## Publishing external, public plugins for others to use
+For the purposes of this tutorial, we will use the [uv Python package manager](https://docs.astral.sh/uv/) to install the carbon.txt validator in a new project. In the next few steps, we will setup our project.
 
-Internal plugins are useful for when you want to extend the validator to meet needs that only you have.
+1. Follow the [installation steps](https://docs.astral.sh/uv/getting-started/installation/) to install uv on your system.
 
-The Carbon.txt validator plugin system, pluggy, is designed to support the creation of plugins so that if you have some code that might be useful to others, then you can publish it to a publicly accessibly repository like PyPi, for others to easily use in their projects.
+```bash
+mkdir carbon-txt-check-online
+cd carbon-txt-check-online
+```
 
-If you have already made an internal only plugin the process is not that different. You use almost the same actual python code to define how your plugin works when called, but you because you are making a publicly available, _external_ plugin, you need two extra things:
+3. Initiate a project using uv to create a Python package, and specify the Python version to use.
 
-1. a file that describes how your plugin is to consumed in projects, called a `pyproject.toml` file
-2. a folder stucture that follows conventions for publishing python packages, that a number of tools can autogenerate for you. For this example, we use `uv`.
+```bash
+uv init --package carbon-txt-check-online --python 3.11
+```
 
-We'll cover the `pyproject.toml` file first to explain what goes in it, and then how to generate a package that can be published to a repository like Pypi
+4. Install the carbon.txt validator into the project
+
+```bash
+uv add carbon-txt
+```
+
+You can check that the carbon.txt validator has been successfully installed by running the `uv tool run carbon-txt` command. This will return some documentation for the different commands available with the carbon.txt validator.
+
+It is also worth being aware that under the hood, the carbon.txt validator uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
+
+## Making a public plugin
+
+The plugin we are building in this tutorial will:
+
+1. Read the content of a carbon.txt file that is discovered by the validator
+2. When it finds a `url` property, it will send a HTTP request to that URL to see if the file is reachable.
+
+We are building a plugin that we intend to share with others, so that they can also use it with the carbon.txt validator. To do this, we will need to specify how our plugin is consumed by using a `pyproject.toml` file, and also adhere to the folder structure conventions for published Python packages. Since we're using `uv` for this tutorial, we will rely on it to help us with this work.
+
+<aside class="alert bg-base-200 text-base-content">
+<p>We're using <code>carbon-txt-check-online</code> for this example, but please bear in mind you'll need a different name (that one's taken for creating a demo plugin for these docs!).</p>
+</aside>
 
 ### Creating our `pyproject.toml` file
 
-This file does not need to be very large, and we'll cover each of the three sections below after presenting the full file:
+When we ran the `uv init` command earlier, `uv` setup our Python project and also created a `pyproject.toml` file for us. Open this file in your text editor. It will look something like this:
 
 ```toml
 [project]
 name = "carbon-txt-check-online"
-version = "0.0.1"
-description = "A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online."
+version = "0.1.0"
+description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
-dependencies = ["httpx", "carbon-txt"]
-
-[project.entry-points.carbon_txt]
-check_online = "carbon_txt_check_online"
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires-python = ">=3.11"
+dependencies = ["carbon-txt>=0.0.13"]
 ```
 
-#### Add the info for your "project" section
-
-We'll briefly cover each element one by one in the project section, but remmember, more detailed guidance is [available on the page published by Pypa, Writing your pyproject.toml](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/):
-
-- `name`  - your project needs a name. For it to be recognised as a plugin for the carbon.txt validator it needs to begin with `carbon-txt`, like `carbon-txt-check-online` for example.
-- `version` - you'll need a version identifier so that people downloading your published project know which version do download
-- `description` - Yup, you project will be easier to use if you descrtibe what it does. For our `carbon-txt-check-online`, plugin, we have _A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online._
-- `readme` - what will be shown as the content when you publish it for others to download from somewhere like Pypi. This defaults to the project `README.md` file
-- `requires-python`- which versions of python you support. Python 3.11 or 3.12 are both supported, but if you wanted to only support python 3.12, you would use `">=3.12"`
-- `dependencies` - which other projects this relies on. In our exmaple, we are extending the carbon.txt validator which is identified as `carbon-txt`, and we are making HTTP requests, so we use the helpful `httpx` library. We use a simple list like so: `["httpx", "carbon-txt"]`
-
-Now that we've covered this key points the text below should make some sense:
+Let's update the description, so that it reflects what our plugin will do. We will also need to update our project dependencies to include `httpx` which we will use later to make HTTP requests that check if a file is available online. Our updated `pyproject.toml` file will look like this:
 
 ```toml
 [project]
 name = "carbon-txt-check-online"
-version = "0.0.1"
+version = "0.1.0"
 description = "A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = ["httpx", "carbon-txt"]
 ```
-
-If we install this though, how does our carbon.txt validator know to try using it? That's the next section
 
 #### Add the entry points to be recognised as a plugin
 
-The lines below are required for the carbon.txt validator project, identified as `carbon-txt` to use the code in this plugin.
+Adding a project entry point will inform the carbon.txt validator on how to use our plugin. Add the lines below to the end of your `pyproject.toml` file.
 
 ```toml
 [project.entry-points.carbon_txt]
@@ -94,17 +100,11 @@ check_online = "carbon_txt_check_online"
 
 The line `[project.entry-points.carbon_txt]` is a way of flagging up that this plugin can be considered a valid entry point for the `carbon_txt` project.
 
-Beneath it, the `carbon_txt_check_online` is the path to the python file that contains the same code we saw use in the 'internal' plugin - the different is that rather than listing a path to a directory in file system, we are listing an path to a python module, that our plugin will have been downloaded into when used in a project.
+Beneath it, the `carbon_txt_check_online` is the path to the python file that contains a python module that our plugin will be downloaded into when used in a project.
 
-Name the first part with the par you intend to use after the `carbon-txt` prefix. If your project name is `carbon-txt-check-online`, then use `check_online` to identify this entry point.
+#### Add a build backend
 
-With these two sections, we have described our project, and defined a way to signify to projects like the carbon.txt validator that it's designed to work with it.
-
-Now need a way to actually package up the code for publishing though.
-
-#### Add the build backend, so the project can be built and published
-
-Ths final stanza sets out how this project should be built, when it's published. Python is a massive ecosystem, and there are various tools that take python code, then turn it into a compressed file to store on a public repository like Pypi. The oen below is the default and simplest one, and for most cases it should be fine, so we use. You don't need to understand what hatchling is, or really what a build backend is, but if you want to know then the [Python packaging guide as some helpful info](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend):
+Adding a build backend allows us to publish this project to a public Python repository like Pypi. For the purpose of this tutorial, we will use the default build backend. We do not need to know what hatchling is, but if you want to know then the [Python packaging guide as some helpful info](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend). Add these lines to the end of your `pyproject.toml` file.
 
 ```toml
 [build-system]
@@ -112,17 +112,28 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 ```
 
+Once you've completed those steps, your `pyproject.toml` file should look like the one below.
+
+```toml
+[project]
+name = "carbon-txt-check-online"
+version = "0.1.0"
+description = "A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["httpx", "carbon-txt"]
+
+[project.entry-points.carbon_txt]
+check_online = "carbon_txt_check_online"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
 ### Creating our project structure
 
-Now that we more or less know what a `pyproject.toml` file is, and that how, when combined with our existing python plugin code, shows how the code can be shared and consumed, we just need a way to create the project to hold it all.
-
-One of the fastest ways to do this is to use a tool, `uv` to create a starter library package with the correct folder structure, with it's handy `init` command. We're creating a package to publish and for others to consume, so we pass the `--package` flag, follow by the name of our plugin:
-
-```
-uv init --package carbon-txt-check-online
-```
-
-This will create a file structure like so, with hopefully some files and folder names and you might recognise from the config earlier.
+The `uv init` command we ran earlier also created the project structure for our package. It should look like this.
 
 ```
 tree ./carbon-txt-check-online/
@@ -132,45 +143,96 @@ tree ./carbon-txt-check-online/
 ├── README.md
 ├── pyproject.toml
 ├── src
-│   └── carbon_txt_check_online
-│       └── __init__.py
-└── uv.lock
+    └── carbon_txt_check_online
+        └── __init__.py
+```
+
+We've already updated the content of the `pyproject.toml` here. Now, let's update the code that will run for our plugin. To do this, we will edit the `src/carbon_txt_check_online/__init__.py` file.
+
+### Adding our plugin code
+
+The carbon.txt validator comes with documentation about the different plugin hooks available. This can be found at [https://carbon-txt-validator.readthedocs.io/en/latest/plugin_hooks.html](https://carbon-txt-validator.readthedocs.io/en/latest/plugin_hooks.html).
+
+From these docs, we can see that there is a hook called `process_document` that fires for every single `Disclosure` object found in a carbon.txt file. The [carbon.txt syntax](https://carbontxt.org/syntax) specifies that each `Disclosure` object must contain a `doc_type` and `url` property. So, for our plugin, we will trigger it to run using the `process_document` hook, and then look for value of the `url` property.
+
+Inside our `src/carbon_txt_check_online/__init__.py` file, we import `logging`, `httpx`, and the `hookimpl` decorator from the `carbon_txt.plugins` module. We then implement a method _with the same name as our desired hook_ (`process_document`), and add the `@hookimpl` decorator applied to the method. This is how the carbon.txt validator plugin system knows to run it.
+
+The final code for our plugin will look like this:
+
+```python
+# saved to ./src/carbon_txt_check_online/__init__.py
+
+import logging
+
+import httpx
+from carbon_txt.plugins import hookimpl
+
+# every plugin needs a name
+plugin_name = "carbon_txt_check_online"
+
+
+@hookimpl
+def process_document(document, logs):
+    # we send a HEAD request, as we are not trying to download the file.
+    # and check the contents - we just want to see that it's reachable
+    response = httpx.head(document.url, follow_redirects=True)
+
+    if response.status_code == 200:
+        logs.append(f"{plugin_name}: File is online: {document.url}")
+        file_online = True
+    else:
+        logs.append(f"{plugin_name}: File is offline: {document.url}")
+        file_online = False
+
+    check_results = {
+        "url": document.url,
+        "file_online": file_online,
+    }
+
+    # because processing a document can result in multiple results being
+    # returned we always return a list of results
+    results = [check_results]
+
+    return {
+        # return the logs so we see the output in response seen by the user
+        "logs": logs,
+        # return the name of the plugin, so we can tell the output plugins apart
+        "plugin_name": plugin_name,
+        # return the results of prcoessing the document - in our case a
+        # check to see if it's online
+        "document_results": results,
+    }
+
 
 ```
 
-You replace the contents of the `pyproject.toml` with the one we ran through together, and you put the python code containing the hooks you are using in `src/carbon_txt_check_online/__init__.py`. The `uv.lock` file is created when you first run a command inside the project, to execute code, and lists all the downloaded dependencies.
-
-```{admonition} Info
-We're using `carbon-txt-check-online` for this example, but please bear in mind you'll need a different name (that one's taken for creating a demo plugin for these docs!).
-```
-
-### Running code in the external plugin
+### Testing that it works
 
 Assuming you have put the code in the correct place, if you are in that project structure, you should now be able to run `carbon-txt` validator binary, and see your plugin in use.
 
-Run `carbon-txt plugins` to see a list of active plugins:
+Inside the `carbon-txt-check-online` folder that we created at the start of this project, run the `carbon-txt plugins` command to see a list of active plugins:
 
-```
+```bash
 uv run carbon-txt plugins
 ```
 
 Your plugin should be visible:
 
-```
+```bash
 Active plugins:
 
  - carbon_txt_check_online
 ```
 
-Similarly, you should see the plugin in use when you run the same invokation to validate a carbon.txt file online. Once again, we use `uv run` in this case to simulate running this project like it's already been built, published, downloaded and made available to your python environment.
+Now we can also test that our plugin returns works using the carbon.txt validator. To do this, we will run the carbon.txt validator using `uv` and ask it to validate a domain that contains a carbon.txt file. Notice how we are not explicitly telling the carbon.txt validator to use a plugin, but we expect that it will be using the plugin that we've just created.
 
-```
-uv run carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir my_plugins/
+```bash
+uv run carbon-txt validate domain used-in-tests.carbontxt.org
 ```
 
-Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section:
+Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section being the additional information the _our plugin_ is adding to the carbon.txt validator response.
 
-```
+```bash
 Attempting to resolve domain: used-in-tests.carbontxt.org
 Trying a DNS delegated lookup for domain used-in-tests.carbontxt.org
 Checking if a carbon.txt file is reachable at https://used-in-tests.carbontxt.org/carbon.txt
@@ -191,13 +253,13 @@ Results of processing linked documents in the carbon.txt file:
 {'carbon_txt_check_online': [{'url': 'https://used-in-tests.carbontxt.org/our-climate-record', 'file_online': True}]}
 ```
 
-#### Actually publishing your package
+## Publishing the plugin for others to use
 
 Publishing a software package to a repository like Pypi is beyond the scope of this documentation, but the [guide on PyPa, Packaging Python Projects](https://packaging.python.org/en/latest/tutorials/packaging-projects/) is a helpful resource.
 
-**A quick workaround, just to see it working**
+### Using plugins that aren't published on Pypi
 
-If you don't want to jump through all these steps, and you have a created an external project that is already published on somewhere like Github, then there is a handy shortcut.
+If you have created a plugin, but do not want to/are not ready to publish it on Pypi, then you can still shared it for others to use if it is hosted on a public repository like Github.
 
 Normally if you wanted to use this new external plugin, `carbon-txt-check-online` in a different project, and you have published it to Pypi, your `pyproject.toml` file might look like this:
 
@@ -211,19 +273,7 @@ dependencies = [
 
 If you have uploaded the code to somewhere like Github, you can take advantage of git support in `pyproject.toml` files, to fetch it from a site like Github instead.
 
-You can 'cheat' and point to the Github repository as a short cut, by adding a `@`, and then listing the path to the repository using the special `git+https` protocol to denote that this is a package to download from Github. If a project is accessible in your browser at this url:
-
-```
-https://github.com/thegreenwebfoundation/carbon-txt-check-online
-```
-
-Then the `git+https` link would be:
-
-```
-git+https://github.com/thegreenwebfoundation/carbon-txt-check-online.git
-```
-
-This means your list of dependencies will look like this instead:
+You can point to the GitHub repository instead by adding an `@`, and then listing the URL of the repository using the special `git+https` protocol to denote that this is a package to download from GitHub. If a project is accessible in your browser at this url `https://github.com/thegreenwebfoundation/carbon-txt-check-online`, then the `git+https` link would be `git+https://github.com/thegreenwebfoundation/carbon-txt-check-online.git`. This means your list of dependencies will look like this instead:
 
 ```toml
 dependencies = [
@@ -233,11 +283,11 @@ dependencies = [
 ]
 ```
 
-When you next try to install the dependencies in your project, the other projects will be downloaded from PyPi as usual, but because of the extra git link, the `carbon-txt-check-online` project will be downloaded from Github instead.
+When you next try to install the dependencies in your project, the other projects will be downloaded from PyPi as usual, but because of the extra git link, the `carbon-txt-check-online` project will be downloaded from GitHub instead.
 
 This is very handy for testing external plugins before 'officially' publishing them!
 
-#### A reference external plugin
+## Source code
 
 If you want to see the completed external plugin, there is a demo plugin to download and learn from on github at:
 

--- a/src/docs/carbon-txt/tutorials/make-a-public-plugin.md
+++ b/src/docs/carbon-txt/tutorials/make-a-public-plugin.md
@@ -1,0 +1,244 @@
+---
+title: "Make a public plugin to use with the carbon.txt CLI"
+description: "In this tutorial, you will learn how to make a public plugin that can be used with the carbon.txt CLI."
+eleventyNavigation:
+  key: make-public-plugin
+  title: "Make a public plugin to use with the carbon.txt CLI"
+  #     parent: overview
+  sectionTitle: Tutorials
+  order: 13
+---
+
+# {{ title }}
+
+## How to implement plugins for the carbon.txt validator
+
+The carbon-txt validator is designed to support extending its functionality via a plugin system, and there are two supported ways to do use it.
+
+1. **Internal plugins for internal use**, via the `--plugins-dir` command line flag
+2. **Publishing plugins for others to use**, as a Python Package
+
+Under the hood, the system uses [Pluggy](https://pluggy.readthedocs.io/), a widely used framework for building plugin systems, based around exposing a set of "hooks", at various stages of the lifecycle of running the validator.
+
+By implmenting functions that use the appropriate hook, you can extend the functionlaity of the carbon.txt validator.
+
+A number of well known python projects use this plugin, like [Datasette](https://docs.datasette.io/en/stable/writing_plugins.html#writing-one-off-plugins), [LLM](https://llm.datasette.io/en/stable/plugins/index.html), [Pytest](https://docs.pytest.org/en/latest/how-to/writing_plugins.html#pip-installable-plugins), [Tox](https://tox.wiki/en/latest/plugins.html#) and others. It is well documented and battle tested.
+
+## Publishing external, public plugins for others to use
+
+Internal plugins are useful for when you want to extend the validator to meet needs that only you have.
+
+The Carbon.txt validator plugin system, pluggy, is designed to support the creation of plugins so that if you have some code that might be useful to others, then you can publish it to a publicly accessibly repository like PyPi, for others to easily use in their projects.
+
+If you have already made an internal only plugin the process is not that different. You use almost the same actual python code to define how your plugin works when called, but you because you are making a publicly available, _external_ plugin, you need two extra things:
+
+1. a file that describes how your plugin is to consumed in projects, called a `pyproject.toml` file
+2. a folder stucture that follows conventions for publishing python packages, that a number of tools can autogenerate for you. For this example, we use `uv`.
+
+We'll cover the `pyproject.toml` file first to explain what goes in it, and then how to generate a package that can be published to a repository like Pypi
+
+### Creating our `pyproject.toml` file
+
+This file does not need to be very large, and we'll cover each of the three sections below after presenting the full file:
+
+```toml
+[project]
+name = "carbon-txt-check-online"
+version = "0.0.1"
+description = "A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["httpx", "carbon-txt"]
+
+[project.entry-points.carbon_txt]
+check_online = "carbon_txt_check_online"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+#### Add the info for your "project" section
+
+We'll briefly cover each element one by one in the project section, but remmember, more detailed guidance is [available on the page published by Pypa, Writing your pyproject.toml](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/):
+
+- `name`  - your project needs a name. For it to be recognised as a plugin for the carbon.txt validator it needs to begin with `carbon-txt`, like `carbon-txt-check-online` for example.
+- `version` - you'll need a version identifier so that people downloading your published project know which version do download
+- `description` - Yup, you project will be easier to use if you descrtibe what it does. For our `carbon-txt-check-online`, plugin, we have _A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online._
+- `readme` - what will be shown as the content when you publish it for others to download from somewhere like Pypi. This defaults to the project `README.md` file
+- `requires-python`- which versions of python you support. Python 3.11 or 3.12 are both supported, but if you wanted to only support python 3.12, you would use `">=3.12"`
+- `dependencies` - which other projects this relies on. In our exmaple, we are extending the carbon.txt validator which is identified as `carbon-txt`, and we are making HTTP requests, so we use the helpful `httpx` library. We use a simple list like so: `["httpx", "carbon-txt"]`
+
+Now that we've covered this key points the text below should make some sense:
+
+```toml
+[project]
+name = "carbon-txt-check-online"
+version = "0.0.1"
+description = "A demonstration carbon.txt plugin that checks whether linked documents in a carbon.txt file are still online."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["httpx", "carbon-txt"]
+```
+
+If we install this though, how does our carbon.txt validator know to try using it? That's the next section
+
+#### Add the entry points to be recognised as a plugin
+
+The lines below are required for the carbon.txt validator project, identified as `carbon-txt` to use the code in this plugin.
+
+```toml
+[project.entry-points.carbon_txt]
+check_online = "carbon_txt_check_online"
+```
+
+The line `[project.entry-points.carbon_txt]` is a way of flagging up that this plugin can be considered a valid entry point for the `carbon_txt` project.
+
+Beneath it, the `carbon_txt_check_online` is the path to the python file that contains the same code we saw use in the 'internal' plugin - the different is that rather than listing a path to a directory in file system, we are listing an path to a python module, that our plugin will have been downloaded into when used in a project.
+
+Name the first part with the par you intend to use after the `carbon-txt` prefix. If your project name is `carbon-txt-check-online`, then use `check_online` to identify this entry point.
+
+With these two sections, we have described our project, and defined a way to signify to projects like the carbon.txt validator that it's designed to work with it.
+
+Now need a way to actually package up the code for publishing though.
+
+#### Add the build backend, so the project can be built and published
+
+Ths final stanza sets out how this project should be built, when it's published. Python is a massive ecosystem, and there are various tools that take python code, then turn it into a compressed file to store on a public repository like Pypi. The oen below is the default and simplest one, and for most cases it should be fine, so we use. You don't need to understand what hatchling is, or really what a build backend is, but if you want to know then the [Python packaging guide as some helpful info](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend):
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+### Creating our project structure
+
+Now that we more or less know what a `pyproject.toml` file is, and that how, when combined with our existing python plugin code, shows how the code can be shared and consumed, we just need a way to create the project to hold it all.
+
+One of the fastest ways to do this is to use a tool, `uv` to create a starter library package with the correct folder structure, with it's handy `init` command. We're creating a package to publish and for others to consume, so we pass the `--package` flag, follow by the name of our plugin:
+
+```
+uv init --package carbon-txt-check-online
+```
+
+This will create a file structure like so, with hopefully some files and folder names and you might recognise from the config earlier.
+
+```
+tree ./carbon-txt-check-online/
+
+
+./carbon-txt-check-online/
+├── README.md
+├── pyproject.toml
+├── src
+│   └── carbon_txt_check_online
+│       └── __init__.py
+└── uv.lock
+
+```
+
+You replace the contents of the `pyproject.toml` with the one we ran through together, and you put the python code containing the hooks you are using in `src/carbon_txt_check_online/__init__.py`. The `uv.lock` file is created when you first run a command inside the project, to execute code, and lists all the downloaded dependencies.
+
+```{admonition} Info
+We're using `carbon-txt-check-online` for this example, but please bear in mind you'll need a different name (that one's taken for creating a demo plugin for these docs!).
+```
+
+### Running code in the external plugin
+
+Assuming you have put the code in the correct place, if you are in that project structure, you should now be able to run `carbon-txt` validator binary, and see your plugin in use.
+
+Run `carbon-txt plugins` to see a list of active plugins:
+
+```
+uv run carbon-txt plugins
+```
+
+Your plugin should be visible:
+
+```
+Active plugins:
+
+ - carbon_txt_check_online
+```
+
+Similarly, you should see the plugin in use when you run the same invokation to validate a carbon.txt file online. Once again, we use `uv run` in this case to simulate running this project like it's already been built, published, downloaded and made available to your python environment.
+
+```
+uv run carbon-txt validate domain used-in-tests.carbontxt.org --plugins-dir my_plugins/
+```
+
+Our output should look something like the output below, with the extra `Results of processing linked documents in the carbon.txt file` section:
+
+```
+Attempting to resolve domain: used-in-tests.carbontxt.org
+Trying a DNS delegated lookup for domain used-in-tests.carbontxt.org
+Checking if a carbon.txt file is reachable at https://used-in-tests.carbontxt.org/carbon.txt
+New Carbon text file found at: https://used-in-tests.carbontxt.org/carbon.txt
+Carbon.txt file parsed as valid TOML.
+Parsed TOML was recognised as valid Carbon.txt file.
+
+✅ Carbon.txt file syntax is valid!
+
+-------
+
+
+CarbonTxtFile(upstream=Upstream(providers=[]), org=Organisation(disclosures=[Disclosure(domain='used-in-tests.carbontxt.org', doc_type='sustainability-page', url='https://used-in-tests.carbontxt.org/our-climate-record')]))
+-------
+
+Results of processing linked documents in the carbon.txt file:
+
+{'carbon_txt_check_online': [{'url': 'https://used-in-tests.carbontxt.org/our-climate-record', 'file_online': True}]}
+```
+
+#### Actually publishing your package
+
+Publishing a software package to a repository like Pypi is beyond the scope of this documentation, but the [guide on PyPa, Packaging Python Projects](https://packaging.python.org/en/latest/tutorials/packaging-projects/) is a helpful resource.
+
+**A quick workaround, just to see it working**
+
+If you don't want to jump through all these steps, and you have a created an external project that is already published on somewhere like Github, then there is a handy shortcut.
+
+Normally if you wanted to use this new external plugin, `carbon-txt-check-online` in a different project, and you have published it to Pypi, your `pyproject.toml` file might look like this:
+
+```toml
+dependencies = [
+    "some-other-dependency",
+    "carbon-txt",
+    "carbon-txt-check-online"
+]
+```
+
+If you have uploaded the code to somewhere like Github, you can take advantage of git support in `pyproject.toml` files, to fetch it from a site like Github instead.
+
+You can 'cheat' and point to the Github repository as a short cut, by adding a `@`, and then listing the path to the repository using the special `git+https` protocol to denote that this is a package to download from Github. If a project is accessible in your browser at this url:
+
+```
+https://github.com/thegreenwebfoundation/carbon-txt-check-online
+```
+
+Then the `git+https` link would be:
+
+```
+git+https://github.com/thegreenwebfoundation/carbon-txt-check-online.git
+```
+
+This means your list of dependencies will look like this instead:
+
+```toml
+dependencies = [
+    "some-other-dependency",
+    "carbon-txt",
+    "carbon-txt-check-online @ git+https://github.com/thegreenwebfoundation/carbon-txt-check-online.git",
+]
+```
+
+When you next try to install the dependencies in your project, the other projects will be downloaded from PyPi as usual, but because of the extra git link, the `carbon-txt-check-online` project will be downloaded from Github instead.
+
+This is very handy for testing external plugins before 'officially' publishing them!
+
+#### A reference external plugin
+
+If you want to see the completed external plugin, there is a demo plugin to download and learn from on github at:
+
+[https://github.com/thegreenwebfoundation/carbon-txt-check-online](https://github.com/thegreenwebfoundation/carbon-txt-check-online)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -348,3 +348,7 @@ seven-minute-tabs [role="tabpanel"] pre:last-child {
 .roadmap-list > li > div:last-child {
   margin-block-end: 1.25rem;
 }
+
+.language-toml .table {
+  display: initial;
+}


### PR DESCRIPTION
This PR added documentation for the carbon.txt project. Specifically, it adds:

- An overview page for the project
- An explainer about the carbon.txt validator's architecture
- Two tutorials for creating private and public plugins that extend the carbon.txt validator
