### PR TITLE
Add a note about Electricity Maps API limits to docs

### DIFF
--- a/src/_includes/partials/gaw-emaps-note.njk
+++ b/src/_includes/partials/gaw-emaps-note.njk
@@ -1,0 +1,10 @@
+<aside class="alert alert-info text-base-content">
+    <p>
+        <strong>Note:</strong>
+        The Electricity Maps API free plan currently limits access to data for one (1) zone. This means that Grid-aware Websites
+        can only currently be applied to users in a single region when using the Electricity Maps API free plan. We are in
+        contact with the Electricity Maps team about the possibility of expanding access to data for multiple regions. You can
+        track the progress of this issue on
+        <a href="https://github.com/thegreenwebfoundation/grid-aware-websites/issues/21">GitHub</a>.
+    </p>
+</aside>

--- a/src/docs/grid-aware-websites/getting-started.md
+++ b/src/docs/grid-aware-websites/getting-started.md
@@ -23,6 +23,8 @@ You can check whether or not you have Node installed by running `node --version`
 
 You will also require an API key to access the [Electricity Maps API](https://api-portal.electricitymaps.com/).
 
+{% include 'partials/gaw-emaps-note.njk' %}
+
 ## Installation
 
 Make a directory for your project, and then inside of that directory setup your project using NPM.

--- a/src/docs/grid-aware-websites/tutorials/grid-aware-tutorial-cloudflare-workers.md
+++ b/src/docs/grid-aware-websites/tutorials/grid-aware-tutorial-cloudflare-workers.md
@@ -33,6 +33,8 @@ You should have:
 
 You should also be aware of the limits and pricing of Cloudflare Workers, available on the [Cloudflare website](https://developers.cloudflare.com/workers/platform/).
 
+{% include 'partials/gaw-emaps-note.njk' %}
+
 <aside class="alert alert-info text-base-content">
 <p>For the purposes of this tutorial, we will demonstrate deploying a Cloudflare Worker to run on our own Green Web Foundation domain (`thegreenwebfoundation.org`). <strong>When following along with this tutorial, you should use your own domain</strong>.</p>
 </aside>

--- a/src/docs/grid-intensity-cli/explainer/providers.md
+++ b/src/docs/grid-intensity-cli/explainer/providers.md
@@ -31,7 +31,7 @@ When no provider is set, the CLI will use Ember as the default.
 
 <aside class="alert  alert-warning"><div>
 <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-	<p>Please note that some providers require user account and/or API tokens to be set as well.</p>
+ <p>Please note that some providers require user account and/or API tokens to be set as well.</p>
 </div></aside>
 
 ## Ember <span class="badge align-middle badge-secondary badge-lg">Default</span>
@@ -81,7 +81,7 @@ WattTime is a nonprofit that offers technology solutions that make it easy for a
 
 When using WattTime, you will need to pass a location that is supported by the WattTime API. WattTime's API documentation details how you can [get a list of locations](https://www.watttime.org/api-documentation/#list-of-grid-regions), or [use latitude & longitude](https://www.watttime.org/api-documentation/#determine-grid-region) to find a specific location.
 
-For example, running the command below returns an array data for California Independent System Operator (North). 
+For example, running the command below returns an array data for California Independent System Operator (North).
 
 ```bash
 grid-intensity --provider WattTime --location CAISO_NORTH
@@ -118,7 +118,6 @@ Each location will return a `percent` field. This value represents the relative 
 
 If you require absolute Marginal Operating Emissions Rate (MOER) data, this is available for free when querying the `CAISO_NORTH` location as shown above. However, you will require a [_WattTime Pro subscription_](https://www.watttime.org/get-the-data/data-plans/) to obtain this data for other locations.
 
-
 ***
 
 ## Electricity Maps <div class="badge badge-warning gap-2 align-middle">API token required</div>
@@ -150,16 +149,16 @@ grid-intensity --provider ElectricityMaps --location PT
 # Returns
 
 [
-	{
-		"emissions_type": "average",
-		"metric_type": "absolute",
-		"provider": "ElectricityMaps",
-		"location": "PT",
-		"units": "gCO2e per kWh",
-		"valid_from": "2023-07-14T10:00:00Z",
-		"valid_to": "2023-07-14T11:00:00Z",
-		"value": 155
-	}
+ {
+  "emissions_type": "average",
+  "metric_type": "absolute",
+  "provider": "ElectricityMaps",
+  "location": "PT",
+  "units": "gCO2e per kWh",
+  "valid_from": "2023-07-14T10:00:00Z",
+  "valid_to": "2023-07-14T11:00:00Z",
+  "value": 155
+ }
 ]
 ```
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -352,3 +352,7 @@ seven-minute-tabs [role="tabpanel"] pre:last-child {
 .language-toml .table {
   display: initial;
 }
+
+aside + aside {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Triage

### Related issue/s

Please list below any issues this pull request is related to.

- https://github.com/thegreenwebfoundation/grid-aware-websites/issues/21

## Describe the changes made in this pull request

This PR adds a note to the related parts of the Grid-aware Websites (GAW) documentation giving visibility to the current limitations of the Electricity Maps API as it applies to GAW.