### PR TITLE
Fix bad const reference in example code

### DIFF
--- a/src/docs/co2js/models.md
+++ b/src/docs/co2js/models.md
@@ -39,7 +39,7 @@ import { co2 } from "@tgwf/co2";
 const swdmV4 = new co2({ model: "swd", version: 4 });
 const bytes = 1000;
 
-const estimate = version4.perByte(1000);
+const estimate = swdmV4.perByte(1000);
 ```
 
 Learn more about the [different methods available when using the Sustainable Web Design Model](/co2js/methods/), including how to adjust variables used within the model.


### PR DESCRIPTION
## Triage

### Related issue/s

None.

## Describe the changes made in this pull request

Minor fix for code example showing how to use SWDM version 4, where the model is set up as `swdmV4` but then incorrectly references the model as `version4`.